### PR TITLE
Add optional endpoint deployment to Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ directory `deployed_values/`
 6. You can access your web service through the ingres or via a port forward 
 to the web service pod. Instructions are provided in the displayed notes.
 
+## Kubernetes Endpoint 
+We can deploy the kubernetes endpoint as a pod as part of this deployment. It 
+needs to have a valid copy of the funcx's `funcx_sdk_tokens.json` which can 
+be created by running on your local workstation and running
+```shell script
+ funcx-endpoint start
+```
+
+You will be prompted to follow the authorization link and paste the resulting 
+token into the console. Once you do that, funcx-endpoint will create a 
+`~/.funcx` directory and provide you with a token file. 
+
+The Kubernetes endpoint expects this file to be available as a Kubernetes
+secret named `funcx-sdk-tokens`. 
+
+You can install this secret with:
+```shell script
+kubectl create secret generic funcx-sdk-tokens --from-file=~/.funcx/credentials/funcx_sdk_tokens.json
+```
+
 ## Database Setup
 Until we migrate the webservice to use an ORM, we need to set the database
 schema up using a SQL script. This is accomplished by an init-container that
@@ -52,6 +72,11 @@ configuration
 | `webService.globusClient`      | Client ID for globus app. Obtained from [http://developers.globus.org](http://developers.globus.org) | |
 | `webService.globusKey`         | Secret for globus app. Obtained from [http://developers.globus.org](http://developers.globus.org) | |
 | `webService.replicas`          | Number of replica web services to deploy                            | 1 |
+| `endpoint.enabled`            | Deploy an internal kubernetes endpoint? | true |
+| `endpoint.replicas`            | Number of replica endpoint pods to deploy | 1 |
+| `endpoint.image`             | Docker image name for the endpoint                               | funcx/kube-endpoint |
+| `endpoint.tag`               | Docker image tag for the endpoint                                | 213_helm_chart |
+| `endpoint.pullPolicy`        | Kubernetes pull policy for the endpoint container                | IfNotPresent |
 | `ingress.enabled`              | Deploy an ingres to route traffic to web app?                       | false |
 | `ingress.host`                 | Host name for the ingress. You will be able to reach your web service via a url that starts with the helm release name and ends with this host | uc.ssl-hep.org |
 | `postgres.enabled`             | Deploy a postgres instance?                                         | true |

--- a/funcx/templates/endpoint-config.yaml
+++ b/funcx/templates/endpoint-config.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.endpoint.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-endpoint-config
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Release.Name }}
+data:
+  config.py: |
+    import getpass
+    from parsl.addresses import address_by_hostname
+
+    global_options = {
+        'username': getpass.getuser(),
+        'email': 'USER@USERDOMAIN.COM',
+        'broker_address': '127.0.0.1',
+        'broker_port': 8088,
+        'endpoint_address': address_by_hostname(),
+    }
+{{- end }}
+

--- a/funcx/templates/endpoint-deployment.yaml
+++ b/funcx/templates/endpoint-deployment.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.endpoint.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-endpoint
+spec:
+  replicas: {{ .Values.endpoint.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-endpoint
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-endpoint
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-endpoint
+        image: {{ .Values.endpoint.image }}:{{ .Values.endpoint.tag }}
+        command: [ "/bin/bash", "-c", "--" ]
+        args: [ "mkdir ~/.funcx; mkdir ~/.funcx/{{ .Release.Name }}; mkdir ~/.funcx/credentials; cp /funcx/config/config.py ~/.funcx; cp /funcx/{{ .Release.Name }}/* ~/.funcx/{{ .Release.Name }}; cp /funcx/credentials/* ~/.funcx/credentials; funcx-endpoint start {{ .Release.Name }}; sleep infinity"]
+        tty: true
+        stdin: true
+        imagePullPolicy: {{ .Values.endpoint.pullPolicy }}
+        {{- if .Values.endpoint.resources }}
+        resources:
+{{ toYaml .Values.endpoint.resources | indent 10 }}
+        {{- end }}
+
+        volumeMounts:
+          - mountPath: "/mnt"
+            name: funcxmnt
+          - name: funcx-sdk-tokens
+            mountPath: /funcx/credentials
+            readOnly: true
+          - name: endpoint-config
+            mountPath: /funcx/config
+          - name: endpoint-instance-config
+            mountPath: /funcx/{{ .Release.Name }}
+
+
+        ports:
+          - containerPort: 5000
+
+      volumes:
+        - name: funcxmnt
+          emptyDir: {}
+        - name: funcx-sdk-tokens
+          secret:
+            secretName: funcx-sdk-tokens
+        - name: endpoint-config
+          configMap:
+            name: {{ .Release.Name }}-endpoint-config
+        - name: endpoint-instance-config
+          configMap:
+            name: {{ .Release.Name }}-endpoint-instance-config
+{{- end }}

--- a/funcx/templates/endpoint-instance-config.yaml
+++ b/funcx/templates/endpoint-instance-config.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.endpoint.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-endpoint-instance-config
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ .Release.Name }}
+data:
+  config.py: |
+    from funcx_endpoint.endpoint.utils.config import Config
+    from parsl.providers import LocalProvider
+
+    config = Config(
+        scaling_enabled=True,
+        provider=LocalProvider(
+            init_blocks=1,
+            min_blocks=1,
+            max_blocks=1,
+        ),
+        max_workers_per_node=2,
+    )
+{{- end }}

--- a/funcx/templates/web-service-config.yaml
+++ b/funcx/templates/web-service-config.yaml
@@ -20,3 +20,4 @@ data:
     DB_PASSWORD = "{{ .Values.postgresql.postgresqlPassword }}"
     DB_HOST = "{{ .Release.Name }}-postgresql"
 
+    FORWARDER_IP = "{{ .Values.forwarderIP }}"

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -17,6 +17,16 @@ webService:
   globusClient: <<your app client>>
   globusKey: <<your app key>>
 
+forwarderIP: host.docker.internal
+
+endpoint:
+  enabled: true
+  image: funcx/kube-endpoint
+  tag: 213_helm_chart
+  pullPolicy: IfNotPresent
+  replicas: 1
+
+
 postgres:
   enabled: true
 


### PR DESCRIPTION
# Problem
Need to be able to deploy the Kubernetes endpoint into the cluster as part of a development deployment

# Approach
Added a deployment along with two config files deployed as ConfigMaps

Assume that the administrator has pushed their credentials as a Secret