### PR TITLE
Add advertised redis host and port to web service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ configuration
 | `webService.dbSetupImage`      | Docker image name for the web service database setup image          | funcx/web-service-db |
 | `webService.dbSetupTag`        | Docker image tag for the web service database setup                 | 213_helm_chart |
 | `webService.dbSetupPullPolicy` | Kubernetes pull policy for the web service database setup container | IfNotPresent |
+| `webService.advertisedRedisPort` | Redis port that the forwarder (outside of cluster) can reach | 6379 |'
+| `webService.advertisedRedisHost` | Redis host that the forwarder (outside of cluster) can reach | localhost |'
 | `webService.globusClient`      | Client ID for globus app. Obtained from [http://developers.globus.org](http://developers.globus.org) | |
 | `webService.globusKey`         | Secret for globus app. Obtained from [http://developers.globus.org](http://developers.globus.org) | |
 | `webService.replicas`          | Number of replica web services to deploy                            | 1 |

--- a/funcx/templates/web-service-config.yaml
+++ b/funcx/templates/web-service-config.yaml
@@ -11,6 +11,9 @@ data:
   app.conf: |
     REDIS_PORT = 6379
     REDIS_HOST = "{{ .Release.Name }}-redis-master"
+
+    ADVERTISED_REDIS_PORT = "{{ .Values.webService.advertisedRedisPort }}"
+    ADVERTISED_REDIS_HOST = "{{ .Values.webService.advertisedRedisHost }}"
     HOSTNAME = "Not Used"
     GLOBUS_CLIENT = "{{ .Values.webService.globusClient }}"
     GLOBUS_KEY = "{{ .Values.webService.globusKey }}"

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -6,12 +6,15 @@ ingress:
 
 webService:
   image: funcx/web-service
-  tag: 213_helm_chart
+  tag: dev
   pullPolicy: IfNotPresent
 
   dbSetupImage: funcx/web-service-db
-  dbSetupTag: 213_helm_chart
+  dbSetupTag: dev
   dbSetupPullPolicy: IfNotPresent
+
+  advertisedRedisPort: 6379
+  advertisedRedisHost: localhost
 
   replicas: 1
   globusClient: <<your app client>>
@@ -22,7 +25,7 @@ forwarderIP: host.docker.internal
 endpoint:
   enabled: true
   image: funcx/kube-endpoint
-  tag: 213_helm_chart
+  tag: dev
   pullPolicy: IfNotPresent
   replicas: 1
 


### PR DESCRIPTION
# Problem
The web service needs to provide the forwarder with a REDIS address and port that are reachable outside of the cluster

# Approach
Add new values and publish them to the web service config template