### PR TITLE
In Cluster Forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ configuration
 | `endpoint.image`             | Docker image name for the endpoint                               | funcx/kube-endpoint |
 | `endpoint.tag`               | Docker image tag for the endpoint                                | 213_helm_chart |
 | `endpoint.pullPolicy`        | Kubernetes pull policy for the endpoint container                | IfNotPresent |
+| `forwarder.enabled`            | Deploy an internal kubernetes forwarder? | true |
+| `forwarder.image`             | Docker image name for the forwarder                               | funcx/funcx/forwarder |
+| `forwarder.tag`               | Docker image tag for the forwarder                                | dev |
+| `forwarder.pullPolicy`        | Kubernetes pull policy for the forwarder container                | IfNotPresent |
 | `ingress.enabled`              | Deploy an ingres to route traffic to web app?                       | false |
 | `ingress.host`                 | Host name for the ingress. You will be able to reach your web service via a url that starts with the helm release name and ends with this host | uc.ssl-hep.org |
 | `postgres.enabled`             | Deploy a postgres instance?                                         | true |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ configuration
 | `endpoint.tag`               | Docker image tag for the endpoint                                | 213_helm_chart |
 | `endpoint.pullPolicy`        | Kubernetes pull policy for the endpoint container                | IfNotPresent |
 | `forwarder.enabled`            | Deploy an internal kubernetes forwarder? | true |
+| `forwarder.minInterchangePort`    | The minimum port to assign interchanges. This will be the first port opened int he pod | 54000 |
+| `forwarder.maxInterchangePort`    | The maximum port to assign interchanges. Only the first three ports are opened in the pod | 54002 |
 | `forwarder.image`             | Docker image name for the forwarder                               | funcx/funcx/forwarder |
 | `forwarder.tag`               | Docker image tag for the forwarder                                | dev |
 | `forwarder.pullPolicy`        | Kubernetes pull policy for the forwarder container                | IfNotPresent |

--- a/funcx/templates/endpoint-deployment.yaml
+++ b/funcx/templates/endpoint-deployment.yaml
@@ -13,6 +13,12 @@ spec:
       labels:
         app: {{ .Release.Name }}-endpoint
     spec:
+      initContainers:
+      - name: check-web-service
+        image: "ncsa/checks:latest"
+        env:
+          - name: URL
+            value: 'http://{{ .Release.Name }}-funcx-web-service:8000/v1/version'
       containers:
       - name: {{ .Release.Name }}-endpoint
         image: {{ .Values.endpoint.image }}:{{ .Values.endpoint.tag }}

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.forwarder.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-forwarder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-forwarder
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-forwarder
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-forwarder
+        image: {{ .Values.forwarder.image }}:{{ .Values.forwarder.tag }}
+        env:
+        - name: REDIS_HOST
+          value: "{{ .Release.Name }}-redis-master"
+        - name: REDIS_PORT
+          value: "6379"
+        - name: ADVERTISED_FORWARDER_ADDRESS
+          value: "{{ .Release.Name }}-forwarder"
+        tty: true
+        stdin: true
+        imagePullPolicy: {{ .Values.forwarder.pullPolicy }}
+        {{- if .Values.forwarder.resources }}
+        resources:
+{{ toYaml .Values.forwarder.resources | indent 10 }}
+        {{- end }}
+        ports:
+          - containerPort: 8080  # Forwarder REST port
+          - containerPort: 54000 # Three forwarder ports to internal endpoint
+          - containerPort: 54001
+          - containerPort: 54002
+{{- end }}

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -23,6 +23,10 @@ spec:
           value: "6379"
         - name: ADVERTISED_FORWARDER_ADDRESS
           value: "{{ .Release.Name }}-forwarder"
+        - name: MIN_IC_PORT
+          value: "{{ .Values.forwarder.minInterchangePort }}"
+        - name: MAX_IC_PORT
+          value: "{{ .Values.forwarder.maxInterchangePort }}"
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.forwarder.pullPolicy }}
@@ -32,7 +36,7 @@ spec:
         {{- end }}
         ports:
           - containerPort: 8080  # Forwarder REST port
-          - containerPort: 54000 # Three forwarder ports to internal endpoint
-          - containerPort: 54001
-          - containerPort: 54002
+          - containerPort: {{ .Values.forwarder.minInterchangePort }}
+          - containerPort: {{ add .Values.forwarder.minInterchangePort 1 }}
+          - containerPort: {{ add .Values.forwarder.minInterchangePort 2 }}
 {{- end }}

--- a/funcx/templates/forwarder-service.yaml
+++ b/funcx/templates/forwarder-service.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.forwarder.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-forwarder
+spec:
+  ports:
+   - port: 8080
+     targetPort: 8080
+     name: "rest"
+     protocol: TCP
+   - port: 54000
+     targetPort: 54000
+     name: "zmq1"
+     protocol: TCP
+   - port: 54001
+     targetPort: 54001
+     name: "zmq2"
+     protocol: TCP
+   - port: 54002
+     targetPort: 54002
+     name: "zmq3"
+     protocol: TCP
+
+  selector:
+    app: {{ .Release.Name }}-forwarder
+  type: ClusterIP
+
+  {{- end }}

--- a/funcx/templates/forwarder-service.yaml
+++ b/funcx/templates/forwarder-service.yaml
@@ -10,16 +10,16 @@ spec:
      targetPort: 8080
      name: "rest"
      protocol: TCP
-   - port: 54000
-     targetPort: 54000
+   - port: {{ .Values.forwarder.minInterchangePort }}
+     targetPort: {{ .Values.forwarder.minInterchangePort }}
      name: "zmq1"
      protocol: TCP
-   - port: 54001
-     targetPort: 54001
+   - port: {{ add .Values.forwarder.minInterchangePort 1 }}
+     targetPort: {{ add .Values.forwarder.minInterchangePort 1 }}
      name: "zmq2"
      protocol: TCP
-   - port: 54002
-     targetPort: 54002
+   - port: {{ add .Values.forwarder.minInterchangePort 2 }}
+     targetPort: {{ add .Values.forwarder.minInterchangePort 2 }}
      name: "zmq3"
      protocol: TCP
 

--- a/funcx/templates/web-service-config.yaml
+++ b/funcx/templates/web-service-config.yaml
@@ -23,4 +23,4 @@ data:
     DB_PASSWORD = "{{ .Values.postgresql.postgresqlPassword }}"
     DB_HOST = "{{ .Release.Name }}-postgresql"
 
-    FORWARDER_IP = "{{ .Values.forwarderIP }}"
+    FORWARDER_IP = "{{ .Release.Name }}-forwarder"

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -29,6 +29,11 @@ endpoint:
   pullPolicy: IfNotPresent
   replicas: 1
 
+forwarder:
+  enabled: true
+  image: funcx/forwarder
+  tag: dev
+  pullPolicy: IfNotPresent
 
 postgres:
   enabled: true

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -33,7 +33,7 @@ forwarder:
   tag: configurable_ic_ports
   pullPolicy: IfNotPresent
   minInterchangePort: 54000
-  maxInterchangePort: 54002
+  maxInterchangePort: 54003
 
 postgres:
   enabled: true

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -20,8 +20,6 @@ webService:
   globusClient: <<your app client>>
   globusKey: <<your app key>>
 
-forwarderIP: host.docker.internal
-
 endpoint:
   enabled: true
   image: funcx/kube-endpoint
@@ -32,8 +30,10 @@ endpoint:
 forwarder:
   enabled: true
   image: funcx/forwarder
-  tag: dev
+  tag: configurable_ic_ports
   pullPolicy: IfNotPresent
+  minInterchangePort: 54000
+  maxInterchangePort: 54002
 
 postgres:
   enabled: true


### PR DESCRIPTION
# Problem
The forwarder needs to be able to bind to numerous ports. This is not supported by kubernetes

# Approach
Modify the forwarder to stick to a three port range which is explicitly exposed by the service