### PR TITLE
Make Postgres and Redis Deployment Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,12 @@ configuration
 | `forwarder.pullPolicy`        | Kubernetes pull policy for the forwarder container                | IfNotPresent |
 | `ingress.enabled`              | Deploy an ingres to route traffic to web app?                       | false |
 | `ingress.host`                 | Host name for the ingress. You will be able to reach your web service via a url that starts with the helm release name and ends with this host | uc.ssl-hep.org |
-| `postgres.enabled`             | Deploy a postgres instance?                                         | true |
+| `services.postgres.enabled`      | Deploy postgres along with service?                             | true |
+| `services.postgres.externalURI`  | If postgres is deployed externally, what URI connects to it?    | sqlite:////sqlite/app.db |
+| `services.redis.enabled`         | Deploy redis along with service?                             | true |
+| `services.redis.externalHost`  | If redis is deployed externally, what is the host name?    |  |
+| `services.redis.externalPort`  | If redis is deployed externally, what is the port?    |  6379 |
+
 
 ## Subcharts
 This chart uses two subcharts to supply dependent services. You can update

--- a/funcx/Chart.yaml
+++ b/funcx/Chart.yaml
@@ -12,11 +12,11 @@ dependencies:
   - name: postgresql
     version: 9.1.4
     repository: https://charts.bitnami.com/bitnami
-    condition: services.postgres
+    condition: services.postgres.enabled
   - name: redis
     version: 10.7.*
     repository: https://charts.bitnami.com/bitnami
-    condition: services.redis
+    condition: services.redis.enabled
   - name: funcx_endpoint
     version: 0.1.0
     repository: http://funcx.org/funcx-helm-charts

--- a/funcx/Chart.yaml
+++ b/funcx/Chart.yaml
@@ -12,10 +12,11 @@ dependencies:
   - name: postgresql
     version: 9.1.4
     repository: https://charts.bitnami.com/bitnami
-    condition: postgres.enabled
+    condition: services.postgres
   - name: redis
     version: 10.7.*
     repository: https://charts.bitnami.com/bitnami
+    condition: services.redis
   - name: funcx_endpoint
     version: 0.1.0
     repository: http://funcx.org/funcx-helm-charts

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         env:
         - name: REDIS_HOST
     {{- if .Values.services.redis.enabled }}
-          value: "{{ .Release.Name }}-redis-master"
+          value: ""
     {{- else }}
           value: "{{  .Values.services.redis.externalHost }}"
     {{- end }}

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -30,10 +30,12 @@ spec:
     {{- else }}
           value: "{{  .Values.services.redis.externalPort }}"
     {{- end }}
+    {{- if not .Values.forwarder.useAWSMetadataServer }}
         - name: ADVERTISED_FORWARDER_ADDRESS
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+    {{- end }}
         - name: TASKS_PORT
           value: "{{ .Values.forwarder.tasksPort }}"
         - name: RESULTS_PORT

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -19,9 +19,17 @@ spec:
         image: {{ .Values.forwarder.image }}:{{ .Values.forwarder.tag }}
         env:
         - name: REDIS_HOST
+    {{- if .Values.services.redis.enabled }}
           value: "{{ .Release.Name }}-redis-master"
+    {{- else }}
+          value: "{{  .Values.services.redis.externalHost }}"
+    {{- end }}
         - name: REDIS_PORT
+    {{- if .Values.services.redis.enabled }}
           value: "6379"
+    {{- else }}
+          value: "{{  .Values.services.redis.externalPort }}"
+    {{- end }}
         - name: ADVERTISED_FORWARDER_ADDRESS
           valueFrom:
             fieldRef:

--- a/funcx/templates/web-service-config.yaml
+++ b/funcx/templates/web-service-config.yaml
@@ -9,8 +9,13 @@ metadata:
     app: {{ .Release.Name }}
 data:
   app.conf: |
+    {{ if .Values.services.redis.enabled }}
     REDIS_PORT = 6379
     REDIS_HOST = "{{ .Release.Name }}-redis-master"
+    {{ else }}
+    REDIS_PORT = {{  .Values.services.redis.externalPort }}
+    REDIS_HOST = "{{  .Values.services.redis.externalHost }}"
+    {{ end }}
 
     ADVERTISED_REDIS_PORT = "{{ .Values.webService.advertisedRedisPort }}"
     ADVERTISED_REDIS_HOST = "{{ .Values.webService.advertisedRedisHost }}"
@@ -18,10 +23,10 @@ data:
     GLOBUS_CLIENT = "{{ .Values.webService.globusClient }}"
     GLOBUS_KEY = "{{ .Values.webService.globusKey }}"
 
-    {{ if .Values.postgres.enabled }}
+    {{ if .Values.services.postgres.enabled }}
     SQLALCHEMY_DATABASE_URI = 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
     {{ else }}
-    SQLALCHEMY_DATABASE_URI = 'sqlite:////sqlite/app.db'
+    SQLALCHEMY_DATABASE_URI = '{{  .Values.services.postgres.externalURI }}'
     {{ end }}
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/funcx/templates/web-service-deployment.yaml
+++ b/funcx/templates/web-service-deployment.yaml
@@ -12,12 +12,14 @@ spec:
       labels:
         app: {{ .Release.Name }}-funcx-web-service
     spec:
+    {{- if .Values.services.postgres.enabled }}
       initContainers:
       - name: check-postgresql
         image: "ncsa/checks:latest"
         env:
           - name: PG_URI
             value: 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
+    {{- end }}
       containers:
       - name: {{ .Release.Name }}-funcx-web-service
         image: {{ .Values.webService.image }}:{{ .Values.webService.tag }}

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -36,8 +36,16 @@ forwarder:
   resultsPort: 55002
   commandsPort: 55003
 
-postgres:
-  enabled: true
+# External services - these should be included for development environment
+# but on EKS we usually use the Amazon supported services
+services:
+  postgres:
+    enabled: true
+    externalURI: sqlite:////sqlite/app.db
+  redis:
+    enabled: true
+    externalHost:
+    externalPort: 6379
 
 postgresql:
   postgresqlUsername: funcx


### PR DESCRIPTION
Fixes #12 

# Approach
Added new settings in `values.yaml`
| Value                          | Desciption                                                          | Default           |
| ------------------------------ | ------------------------------------------------------------------- | ----------------- |
| `services.postgres.enabled`      | Deploy postgres along with service?                             | true |
| `services.postgres.externalURI`  | If postgres is deployed externally, what URI connects to it?    | sqlite:////sqlite/app.db |
| `services.redis.enabled`         | Deploy redis along with service?                             | true |
| `services.redis.externalHost`  | If redis is deployed externally, what is the host name?    |  |
| `services.redis.externalPort`  | If redis is deployed externally, what is the port?    |  6379 |

The externalURI, Host and Port are ignored if helm is deploying these services