### PR TITLE
12 optional services

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ forwarder:
   enabled: true
   tag: forwarder_redesign
   pullPolicy: Always
-  use_local_image: false
   local_image: funcx-forwarder-dev1:latest
 
 redis:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Helm Chart for Deploying funcX stack
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![NSF-2004894](https://img.shields.io/badge/NSF-2004894-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=2004894)
 [![NSF-2004932](https://img.shields.io/badge/NSF-2004932-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=2004932)
- 
+
 This application includes:
 * FuncX Web-Service
 * Kuberentes endpoint
@@ -16,24 +16,24 @@ This application includes:
 ## Preliminaries
 The following dependencies must be set up before you can deploy the helm chart:
 
-## Kubernetes Endpoint 
-We can deploy the kubernetes endpoint as a pod as part of the chart. It 
-needs to have a valid copy of the funcx's `funcx_sdk_tokens.json` which can 
+## Kubernetes Endpoint
+We can deploy the kubernetes endpoint as a pod as part of the chart. It
+needs to have a valid copy of the funcx's `funcx_sdk_tokens.json` which can
 be created by running on your local workstation and running
 ```shell script
  funcx-endpoint start
 ```
 
-You will be prompted to follow the authorization link and paste the resulting 
-token into the console. Once you do that, funcx-endpoint will create a 
-`~/.funcx` directory and provide you with a token file. 
+You will be prompted to follow the authorization link and paste the resulting
+token into the console. Once you do that, funcx-endpoint will create a
+`~/.funcx` directory and provide you with a token file.
 
 The Kubernetes endpoint expects this file to be available as a Kubernetes
-secret named `funcx-sdk-tokens`. 
+secret named `funcx-sdk-tokens`.
 
 You can install this secret with:
 ```shell script
-pushd ~/.funcx 
+pushd ~/.funcx
 kubectl create secret generic funcx-sdk-tokens --from-file=credentials/funcx_sdk_tokens.json
 popd
 ```
@@ -55,7 +55,7 @@ python3 test/create_certs.py -d .curve
 ```
 
 ### Forwarder
-The forwarder needs to be able to open and manage arbitrary ports which is 
+The forwarder needs to be able to open and manage arbitrary ports which is
 not compatible with some of Kubernetes requirements. For now we will run it
 as a docker container, but outside of the cluster.
 
@@ -81,7 +81,7 @@ Launch a copy of forwarder outside of kubernetes, listening on port 8080:
     ```shell script
     helm install -f deployed_values/values.yaml funcx funcx
     ```
-6. You can access your web service through the ingres or via a port forward 
+6. You can access your web service through the ingres or via a port forward
 to the web service pod. Instructions are provided in the displayed notes.
 
 7. You should be able to see the endpoint registering with the web service
@@ -127,7 +127,7 @@ postgresql:
     nodePort: 30432
     type: NodePort
 ```
-There are a few values that can be set to adjust the deployed system 
+There are a few values that can be set to adjust the deployed system
 configuration
 
 | Value                          | Desciption                                                          | Default           |
@@ -159,8 +159,8 @@ configuration
 | `postgres.enabled`             | Deploy a postgres instance?                                         | true |
 
 ## Subcharts
-This chart uses two subcharts to supply dependent services. You can update 
-settings for these by referenceing the subchart name and values from 
+This chart uses two subcharts to supply dependent services. You can update
+settings for these by referenceing the subchart name and values from
 their READMEs.
 
 For example
@@ -171,9 +171,3 @@ postgresql.postgresqlUsername: funcx
 | ---------- | --------------------- |
 | postgresql | [https://github.com/bitnami/charts/tree/master/bitnami/postgresql](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) |
 | redis      | [https://github.com/bitnami/charts/tree/master/bitnami/redis](https://github.com/bitnami/charts/tree/master/bitnami/redis) |
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Similary you need the server secret key `funcx-forwarder-secretkey` for the forw
 ```shell script
 # Make sure the server.key_secret file is in your $PWD/.curve dir
 # You have to get keys from Yadu
-kubectl create secret generic funcx-forwarder-secretkey --from-file=.curve/server.key_secret
+kubectl create secret generic funcx-forwarder-secrets --from-file=.curve/server.key --from-file=.curve/server.key_secret
 ```
 
 > :warning: The `.curve/server.key` must be copied over to the .funcx/<ENDPOINT_NAME>/credentials folder

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ funcx_endpoint:
 forwarder:
   enabled: true
   tag: forwarder_redesign
-  pullPolicy: Never
+  pullPolicy: Always
   use_local_image: false
   local_image: funcx-forwarder-dev1:latest
 

--- a/README.md
+++ b/README.md
@@ -38,21 +38,28 @@ kubectl create secret generic funcx-sdk-tokens --from-file=credentials/funcx_sdk
 popd
 ```
 
-Similary you need the server secret key `funcx-forwarder-secretkey` for the forwarder service.
+
+> :warning: *Only for debugging*: You can set the forwarder curve server key manually by creating
+  a public/secret curve pair, registering them with kubernetes as a secret and then specifying
+  `forwarder.server_cert = true`. By default the forwarder auto generates keys, and distributes it
+  to the endpoint during registration.
+
+To manually setup the keys for debugging, here are the steps:
+
+1. Create your cureve server public/secret keypair with the create_certs.py script:
+
+    ```shell script
+    # CD into the funcx-forwarder repo
+    python3 test/create_certs.py -d .curve
+    ```
+
+2. Similar to the `funcx-sdk-tokens` add the public/secret pair as kubernetes secret:`funcx-forwarder-secrets` for the forwarder service.
 ```shell script
 # Make sure the server.key_secret file is in your $PWD/.curve dir
-# You have to get keys from Yadu
 kubectl create secret generic funcx-forwarder-secrets --from-file=.curve/server.key --from-file=.curve/server.key_secret
 ```
 
-> :warning: The `.curve/server.key` must be copied over to the .funcx/<ENDPOINT_NAME>/credentials folder
-  after a new endpoint is configured.
-
-If you have not setup your server secret key, please make new keys with the create_certs.py script
-```shell script
-# CD into the funcx-forwarder repo
-python3 test/create_certs.py -d .curve
-```
+3. Once the endpoint is registered to the newly deployed `funcx-forwarder`, make sure to check the `~/.funcx/<ENDPOINT_NAME>/certificates/server.key` file to confirm that the manually added key has been returned to the endpoint.
 
 ### Forwarder
 The forwarder needs to be able to open and manage arbitrary ports which is

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This application includes:
 * Postgres database
 * Redis Shared Data Structure
 
+> :warning: **THIS IS A TEST DEPLOYMENT**: The web-service and forwarder can be deployed, while the funcx-endpoint is not yet properly supported
+
 ## Preliminaries
 The following dependencies must be set up before you can deploy the helm chart:
 
@@ -43,6 +45,15 @@ Similary you need the server secret key `funcx-forwarder-secretkey` for the forw
 kubectl create secret generic funcx-forwarder-secretkey --from-file=.curve/server.key_secret
 ```
 
+> :warning: The `.curve/server.key` must be copied over to the .funcx/<ENDPOINT_NAME>/credentials folder
+  after a new endpoint is configured.
+
+If you have not setup your server secret key, please make new keys with the create_certs.py script
+```shell script
+# CD into the funcx-forwarder repo
+python3 test/create_certs.py -d .curve
+```
+
 ### Forwarder
 The forwarder needs to be able to open and manage arbitrary ports which is 
 not compatible with some of Kubernetes requirements. For now we will run it
@@ -57,7 +68,7 @@ Launch a copy of forwarder outside of kubernetes, listening on port 8080:
 1. Make a clone of this repository
 2. Download subcharts:
     ```shell script
-     helm dependency update funcx               
+     helm dependency update funcx
     ```
 3. Create your own `values.yaml` inside the Git ignored directory `deployed_values/`
 4. Obtain Globus Client ID and Secret. Paste them into your values.yaml as
@@ -83,6 +94,40 @@ is run prior to starting up the web service container. This setup image checks
 to see if the tables are there. If not, it runs the setup script.
 
 ## Values
+
+> :warning: **USE THE FOLLOWING dev_values.yaml**
+
+``` yaml
+webService:
+  pullPolicy: Always
+  host: http://localhost:5000
+  globusClient: <GLOBUS_CLIENT_ID_STRING>
+  globusKey: <GLOBUS_CLIENT_KEY_STRING>
+  tag: forwarder_rearch_update
+
+endpoint:
+  enabled: false
+funcx_endpoint:
+  image:
+    tag: exception
+
+forwarder:
+  enabled: true
+  tag: forwarder_redesign
+  pullPolicy: Never
+  use_local_image: false
+  local_image: funcx-forwarder-dev1:latest
+
+redis:
+  master:
+    service:
+      nodePort: 30379
+      type: NodePort
+postgresql:
+  service:
+    nodePort: 30432
+    type: NodePort
+```
 There are a few values that can be set to adjust the deployed system 
 configuration
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ kubectl create secret generic funcx-sdk-tokens --from-file=credentials/funcx_sdk
 popd
 ```
 
+Similary you need the server secret key `funcx-forwarder-secretkey` for the forwarder service.
+```shell script
+# Make sure the server.key_secret file is in your $PWD/.curve dir
+# You have to get keys from Yadu
+kubectl create secret generic funcx-forwarder-secretkey --from-file=.curve/server.key_secret
+```
+
 ### Forwarder
 The forwarder needs to be able to open and manage arbitrary ports which is 
 not compatible with some of Kubernetes requirements. For now we will run it

--- a/README.md
+++ b/README.md
@@ -16,7 +16,51 @@ This application includes:
 ## Preliminaries
 The following dependencies must be set up before you can deploy the helm chart:
 
-## Kubernetes Endpoint
+## FuncX Endpoint
+
+There are two modes in which funcx-endpoints could be deployed:
+
+1. funcx-endpoint deployed outside k8s, connecting to hosted services in k8s
+2. funcx-endpoint deployed with k8s (broken currently)
+
+### Deploying funcx-endpoint externally
+
+Install from the `forwarder_rearch_1` branch of the [funcx repo](https://github.com/funcx-faas/funcX)
+Here are the steps to install, preferably to your active conda environment:
+
+```shell script
+git clone https://github.com/funcx-faas/funcX.git
+cd funcX
+git checkout forwarder_rearch_1
+pip install funcx_sdk
+pip install funcx_endpoint
+```
+
+Next create an endpoint configuration:
+
+```shell script
+funcx-endpoint
+```
+
+Update the configuration file to point the endpoint to locally deployed services, which we will setup in the next sections.
+
+    ```python
+    config = Config(
+    executors=[HighThroughputExecutor(
+        provider=LocalProvider(
+            init_blocks=1,
+            min_blocks=0,
+            max_blocks=1,
+        ),
+    )],
+    funcx_service_address="http://127.0.0.1:5000/api/v1", # <--- UPDATE THIS LINE
+)
+
+     ```
+### Deploying funcx-endpoint into the k8s deployment
+
+> :warning: **THIS IS BROKEN AT THE MOMENT**
+
 We can deploy the kubernetes endpoint as a pod as part of the chart. It
 needs to have a valid copy of the funcx's `funcx_sdk_tokens.json` which can
 be created by running on your local workstation and running

--- a/README.md
+++ b/README.md
@@ -207,7 +207,12 @@ configuration
 | `forwarder.pullPolicy`        | Kubernetes pull policy for the forwarder container                | IfNotPresent |
 | `ingress.enabled`              | Deploy an ingres to route traffic to web app?                       | false |
 | `ingress.host`                 | Host name for the ingress. You will be able to reach your web service via a url that starts with the helm release name and ends with this host | uc.ssl-hep.org |
-| `postgres.enabled`             | Deploy a postgres instance?                                         | true |
+| `services.postgres.enabled`      | Deploy postgres along with service?                             | true |
+| `services.postgres.externalURI`  | If postgres is deployed externally, what URI connects to it?    | sqlite:////sqlite/app.db |
+| `services.redis.enabled`         | Deploy redis along with service?                             | true |
+| `services.redis.externalHost`  | If redis is deployed externally, what is the host name?    |  |
+| `services.redis.externalPort`  | If redis is deployed externally, what is the port?    |  6379 |
+
 
 ## Subcharts
 This chart uses two subcharts to supply dependent services. You can update

--- a/funcx/Chart.yaml
+++ b/funcx/Chart.yaml
@@ -12,11 +12,11 @@ dependencies:
   - name: postgresql
     version: 9.1.4
     repository: https://charts.bitnami.com/bitnami
-    condition: services.postgres
+    condition: services.postgres.enabled
   - name: redis
     version: 10.7.*
     repository: https://charts.bitnami.com/bitnami
-    condition: services.redis
+    condition: services.redis.enabled
   - name: funcx_endpoint
     version: 0.1.0
     repository: http://funcx.org/funcx-helm-charts

--- a/funcx/Chart.yaml
+++ b/funcx/Chart.yaml
@@ -12,10 +12,11 @@ dependencies:
   - name: postgresql
     version: 9.1.4
     repository: https://charts.bitnami.com/bitnami
-    condition: postgres.enabled
+    condition: services.postgres
   - name: redis
     version: 10.7.*
     repository: https://charts.bitnami.com/bitnami
+    condition: services.redis
   - name: funcx_endpoint
     version: 0.1.0
     repository: http://funcx.org/funcx-helm-charts

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -49,13 +49,16 @@ spec:
             hostPort: {{ add .Values.forwarder.commandsPort 1 }}
           - containerPort: 55005 # Debug
             hostPort: 55005
+        {{- if .Values.forwarder.server_cert }}
         volumeMounts:
         - name: funcx-forwarder-secret
           mountPath: /home/funcx/.curve
           readOnly: true
+        {{- end }}
+      {{- if .Values.forwarder.server_cert }}
       volumes:
       - name: funcx-forwarder-secret
         secret:
-          secretName: funcx-forwarder-secretkey
-
+          secretName: funcx-forwarder-secrets
+      {{- end }}
 {{- end }}

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -16,10 +16,11 @@ spec:
       hostNetwork: true
       containers:
       - name: {{ .Release.Name }}-forwarder
-        {{- /*
-        image: {{ .Values.forwarder.image }}:{{ .Values.forwarder.tag }}
-        */}}
+        {{ if .Values.forwarder.use_local_image }}
         image: {{ .Values.forwarder.local_image }}
+        {{ else }}
+        image: {{ .Values.forwarder.image }}:{{ .Values.forwarder.tag }}
+        {{ end }}
         env:
         - name: REDIS_HOST
           value: "{{ .Release.Name }}-redis-master"

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -15,7 +15,10 @@ spec:
     spec:
       containers:
       - name: {{ .Release.Name }}-forwarder
+        {{- /*
         image: {{ .Values.forwarder.image }}:{{ .Values.forwarder.tag }}
+        */}}
+        image: {{ .Values.forwarder.local_image }}
         env:
         - name: REDIS_HOST
           value: "{{ .Release.Name }}-redis-master"
@@ -23,10 +26,12 @@ spec:
           value: "6379"
         - name: ADVERTISED_FORWARDER_ADDRESS
           value: "{{ .Release.Name }}-forwarder"
-        - name: MIN_IC_PORT
-          value: "{{ .Values.forwarder.minInterchangePort }}"
-        - name: MAX_IC_PORT
-          value: "{{ .Values.forwarder.maxInterchangePort }}"
+        - name: TASKS_PORT
+          value: "{{ .Values.forwarder.tasksPort }}"
+        - name: RESULTS_PORT
+          value: "{{ .Values.forwarder.resultsPort }}"
+        - name: COMMANDS_PORT
+          value: "{{ .Values.forwarder.commandsPort }}"
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.forwarder.pullPolicy }}
@@ -36,7 +41,7 @@ spec:
         {{- end }}
         ports:
           - containerPort: 8080  # Forwarder REST port
-          - containerPort: {{ .Values.forwarder.minInterchangePort }}
-          - containerPort: {{ add .Values.forwarder.minInterchangePort 1 }}
-          - containerPort: {{ add .Values.forwarder.minInterchangePort 2 }}
+          - containerPort: {{ add .Values.forwarder.tasksPort 1 }}
+          - containerPort: {{ add .Values.forwarder.resultsPort 1 }}
+          - containerPort: {{ add .Values.forwarder.commandsPort 1 }}
 {{- end }}

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-forwarder
     spec:
+      hostNetwork: true
       containers:
       - name: {{ .Release.Name }}-forwarder
         {{- /*
@@ -25,7 +26,9 @@ spec:
         - name: REDIS_PORT
           value: "6379"
         - name: ADVERTISED_FORWARDER_ADDRESS
-          value: "{{ .Release.Name }}-forwarder"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: TASKS_PORT
           value: "{{ .Values.forwarder.tasksPort }}"
         - name: RESULTS_PORT
@@ -42,6 +45,20 @@ spec:
         ports:
           - containerPort: 8080  # Forwarder REST port
           - containerPort: {{ add .Values.forwarder.tasksPort 1 }}
+            hostPort: {{ add .Values.forwarder.tasksPort 1 }}
           - containerPort: {{ add .Values.forwarder.resultsPort 1 }}
+            hostPort: {{ add .Values.forwarder.resultsPort 1 }}
           - containerPort: {{ add .Values.forwarder.commandsPort 1 }}
+            hostPort: {{ add .Values.forwarder.commandsPort 1 }}
+          - containerPort: 55005 # Debug
+            hostPort: 55005
+        volumeMounts:
+        - name: funcx-forwarder-secret
+          mountPath: /home/funcx/.curve
+          readOnly: true
+      volumes:
+      - name: funcx-forwarder-secret
+        secret:
+          secretName: funcx-forwarder-secretkey
+
 {{- end }}

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -16,11 +16,7 @@ spec:
       hostNetwork: true
       containers:
       - name: {{ .Release.Name }}-forwarder
-        {{ if .Values.forwarder.use_local_image }}
-        image: {{ .Values.forwarder.local_image }}
-        {{ else }}
         image: {{ .Values.forwarder.image }}:{{ .Values.forwarder.tag }}
-        {{ end }}
         env:
         - name: REDIS_HOST
           value: "{{ .Release.Name }}-redis-master"

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         env:
         - name: REDIS_HOST
     {{- if .Values.services.redis.enabled }}
-          value: "{{ .Release.Name }}-redis-master"
+          value: ""
     {{- else }}
           value: "{{  .Values.services.redis.externalHost }}"
     {{- end }}

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -30,10 +30,12 @@ spec:
     {{- else }}
           value: "{{  .Values.services.redis.externalPort }}"
     {{- end }}
+    {{- if not .Values.forwarder.useAWSMetadataServer }}
         - name: ADVERTISED_FORWARDER_ADDRESS
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+    {{- end }}
         - name: TASKS_PORT
           value: "{{ .Values.forwarder.tasksPort }}"
         - name: RESULTS_PORT

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -19,9 +19,17 @@ spec:
         image: {{ .Values.forwarder.image }}:{{ .Values.forwarder.tag }}
         env:
         - name: REDIS_HOST
+    {{- if .Values.services.redis.enabled }}
           value: "{{ .Release.Name }}-redis-master"
+    {{- else }}
+          value: "{{  .Values.services.redis.externalHost }}"
+    {{- end }}
         - name: REDIS_PORT
+    {{- if .Values.services.redis.enabled }}
           value: "6379"
+    {{- else }}
+          value: "{{  .Values.services.redis.externalPort }}"
+    {{- end }}
         - name: ADVERTISED_FORWARDER_ADDRESS
           valueFrom:
             fieldRef:

--- a/funcx/templates/forwarder-service.yaml
+++ b/funcx/templates/forwarder-service.yaml
@@ -10,16 +10,16 @@ spec:
      targetPort: 8080
      name: "rest"
      protocol: TCP
-   - port: {{ .Values.forwarder.minInterchangePort }}
-     targetPort: {{ .Values.forwarder.minInterchangePort }}
+   - port: {{ .Values.forwarder.tasksPort }}
+     targetPort: {{ .Values.forwarder.tasksPort }}
      name: "zmq1"
      protocol: TCP
-   - port: {{ add .Values.forwarder.minInterchangePort 1 }}
-     targetPort: {{ add .Values.forwarder.minInterchangePort 1 }}
+   - port: {{ add .Values.forwarder.resultsPort 1 }}
+     targetPort: {{ add .Values.forwarder.resultsPort 1 }}
      name: "zmq2"
      protocol: TCP
-   - port: {{ add .Values.forwarder.minInterchangePort 2 }}
-     targetPort: {{ add .Values.forwarder.minInterchangePort 2 }}
+   - port: {{ add .Values.forwarder.commandsPort 2 }}
+     targetPort: {{ add .Values.forwarder.commandsPort 2 }}
      name: "zmq3"
      protocol: TCP
 

--- a/funcx/templates/web-service-config.yaml
+++ b/funcx/templates/web-service-config.yaml
@@ -9,8 +9,13 @@ metadata:
     app: {{ .Release.Name }}
 data:
   app.conf: |
+    {{ if .Values.services.redis.enabled }}
     REDIS_PORT = 6379
     REDIS_HOST = "{{ .Release.Name }}-redis-master"
+    {{ else }}
+    REDIS_PORT = {{  .Values.services.redis.externalPort }}
+    REDIS_HOST = "{{  .Values.services.redis.externalHost }}"
+    {{ end }}
 
     ADVERTISED_REDIS_PORT = "{{ .Values.webService.advertisedRedisPort }}"
     ADVERTISED_REDIS_HOST = "{{ .Values.webService.advertisedRedisHost }}"
@@ -18,10 +23,10 @@ data:
     GLOBUS_CLIENT = "{{ .Values.webService.globusClient }}"
     GLOBUS_KEY = "{{ .Values.webService.globusKey }}"
 
-    {{ if .Values.postgres.enabled }}
+    {{ if .Values.services.postgres.enabled }}
     SQLALCHEMY_DATABASE_URI = 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
     {{ else }}
-    SQLALCHEMY_DATABASE_URI = 'sqlite:////sqlite/app.db'
+    SQLALCHEMY_DATABASE_URI = '{{  .Values.services.postgres.externalURI }}'
     {{ end }}
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/funcx/templates/web-service-deployment.yaml
+++ b/funcx/templates/web-service-deployment.yaml
@@ -20,10 +20,11 @@ spec:
             value: 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
       containers:
       - name: {{ .Release.Name }}-funcx-web-service
-        {{- /*
-        image: {{ .Values.webService.image }}:{{ .Values.webService.tag }}
-        */}}
+        {{ if .Values.webService.use_local_image }}
         image: {{ .Values.webService.local_image }}
+        {{ else }}
+        image: {{ .Values.webService.image }}:{{ .Values.webService.tag }}
+        {{ end }}
         env:
         - name: APP_CONFIG_FILE
           value: "/opt/funcx/app.conf"

--- a/funcx/templates/web-service-deployment.yaml
+++ b/funcx/templates/web-service-deployment.yaml
@@ -20,7 +20,10 @@ spec:
             value: 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
       containers:
       - name: {{ .Release.Name }}-funcx-web-service
+        {{- /*
         image: {{ .Values.webService.image }}:{{ .Values.webService.tag }}
+        */}}
+        image: {{ .Values.webService.local_image }}
         env:
         - name: APP_CONFIG_FILE
           value: "/opt/funcx/app.conf"

--- a/funcx/templates/web-service-deployment.yaml
+++ b/funcx/templates/web-service-deployment.yaml
@@ -20,11 +20,7 @@ spec:
             value: 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
       containers:
       - name: {{ .Release.Name }}-funcx-web-service
-        {{ if .Values.webService.use_local_image }}
-        image: {{ .Values.webService.local_image }}
-        {{ else }}
         image: {{ .Values.webService.image }}:{{ .Values.webService.tag }}
-        {{ end }}
         env:
         - name: APP_CONFIG_FILE
           value: "/opt/funcx/app.conf"

--- a/funcx/templates/web-service-deployment.yaml
+++ b/funcx/templates/web-service-deployment.yaml
@@ -12,12 +12,14 @@ spec:
       labels:
         app: {{ .Release.Name }}-funcx-web-service
     spec:
+    {{- if .Values.services.postgres.enabled }}
       initContainers:
       - name: check-postgresql
         image: "ncsa/checks:latest"
         env:
           - name: PG_URI
             value: 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
+    {{- end }}
       containers:
       - name: {{ .Release.Name }}-funcx-web-service
         image: {{ .Values.webService.image }}:{{ .Values.webService.tag }}

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -30,10 +30,11 @@ funcx_endpoint:
 forwarder:
   enabled: true
   image: funcx/forwarder
-  tag: configurable_ic_ports
+  tag: forwarder_redesign
   pullPolicy: IfNotPresent
-  minInterchangePort: 54000
-  maxInterchangePort: 54003
+  tasksPort: 55001
+  resultsPort: 55002
+  commandsPort: 55003
 
 postgres:
   enabled: true

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -36,8 +36,16 @@ forwarder:
   resultsPort: 55002
   commandsPort: 55003
 
-postgres:
-  enabled: true
+# External services - these should be included for development environment
+# but on EKS we usually use the Amazon supported services
+services:
+  postgres:
+    enabled: true
+    externalURI: sqlite:////sqlite/app.db
+  redis:
+    enabled: true
+    externalHost:
+    externalPort: 6379
 
 postgresql:
   postgresqlUsername: funcx


### PR DESCRIPTION
Fixes #12 

# Approach
Added new settings in `values.yaml`
| Value                          | Desciption                                                          | Default           |
| ------------------------------ | ------------------------------------------------------------------- | ----------------- |
| `services.postgres.enabled`      | Deploy postgres along with service?                             | true |
| `services.postgres.externalURI`  | If postgres is deployed externally, what URI connects to it?    | sqlite:////sqlite/app.db |
| `services.redis.enabled`         | Deploy redis along with service?                             | true |
| `services.redis.externalHost`  | If redis is deployed externally, what is the host name?    |  |
| `services.redis.externalPort`  | If redis is deployed externally, what is the port?    |  6379 |

The externalURI, Host and Port are ignored if helm is deploying these services