### PR TITLE
Added commands to install fluentbit in each environment

### DIFF
--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -1,12 +1,24 @@
+ENVIRONMENT?=dev
 
+.PHONY: cluster
 cluster: 
-	eksctl create cluster -f clusterconfig.yml
+	eksctl create cluster -f clusterconfig-$(ENVIRONMENT).yml
 
-
-install-alb-controler-prod:
+.PHONY: install-alb-controler
+install-alb-controler:
 	helm repo add eks https://aws.github.io/eks-charts
-	helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=funcx-prod --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=us-east-1 --set vpcId=vpc-0d3b9f7c3a9c6c1ba
+	helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=funcx-$(ENVIRONMENT) --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=us-east-1 --set vpcId=vpc-0d3b9f7c3a9c6c1ba
 
-install-alb-controler-dev:
-	helm repo add eks https://aws.github.io/eks-charts
-	helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=funcx-dev --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=us-east-1 --set vpcId=vpc-0d3b9f7c3a9c6c1ba
+.PHONY: install-fluentbit
+install-fluentbit:
+	kubectl apply -f https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cloudwatch-namespace.yaml
+	
+	kubectl create configmap fluent-bit-cluster-info \
+	--from-literal=cluster.name=funcx-$(ENVIRONMENT) \
+	--from-literal=http.server=Off \
+	--from-literal=http.port=2020 \
+	--from-literal=read.head=Off \
+	--from-literal=read.tail=On \
+	--from-literal=logs.region=us-east-1 -n amazon-cloudwatch
+	
+	kubectl apply -f https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml


### PR DESCRIPTION
Adding a single makefile command to install fluentbit.  This should address [#170](https://github.com/funcx-faas/funcx-web-service/issues/170).  