### PR TITLE
Pin aws-load-balancer-controller to version 1.1.6

### DIFF
--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -7,7 +7,7 @@ cluster:
 .PHONY: install-alb-controler
 install-alb-controler:
 	helm repo add eks https://aws.github.io/eks-charts
-	helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=funcx-$(ENVIRONMENT) --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=us-east-1 --set vpcId=vpc-0d3b9f7c3a9c6c1ba
+	helm upgrade -i aws-load-balancer-controller --version 1.1.6 eks/aws-load-balancer-controller -n kube-system --set clusterName=funcx-$(ENVIRONMENT) --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=us-east-1 --set vpcId=vpc-0d3b9f7c3a9c6c1ba
 
 .PHONY: install-fluentbit
 install-fluentbit:


### PR DESCRIPTION
# Problem 
The current version of the aws-load-balancer-controller is not compatible with the CloudFormation deployment.
Fixes #22 

# Approach
Add the helm command line argument to set the version to the last known compatible version 1.1.6
