### PR TITLE
Add kubernetes config and instructions for a GitHub Actions user

### DIFF
--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -1,0 +1,71 @@
+# Adding a GitHub Actions User to Cluster
+We created a captive IAM user to be operated by GitHub actions for CI jobs. It
+has very limited powers. Here are the steps to grant it access to the dev
+cluster.
+
+### Grant the IAM user DescribeCluster Permissions on the Cluster
+We will need this to get the Kube config file
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "eks:DescribeCluster",
+            "Resource": "arn:aws:eks:us-east-1:_______________:cluster/funcx-dev"
+        }
+    ]
+}
+```
+
+### Create the role and rolebindings for the github_actions group
+``` bash
+kubectl create -f eks-github-action-access.yaml
+```
+This creates `eks-github-action-role` which is only allowed to list, delete, and 
+patch deployments. It also creates a rolebinding for a group called 
+`github-action-binding`
+
+### Add new user to EKS
+Edit the aws-auth configMap with
+```bash
+kubectl edit -n kube-system configmap/aws-auth
+```
+
+You will need to edit the `mapUsers` property. It should look like:
+```yaml
+  mapUsers: |
+    - userarn: <githubactions ARN>
+      username: githubactions
+      groups:
+        - github-action-binding
+```
+
+### Map the user to the role
+Finally load in the role binding between the user and the role:
+```
+kubectl create -f githubactions-role-binding.yaml
+```
+
+### Put the KubeConfig as a GitHub Repo Secret
+The github action requires the AWS ID and Secret in order to connect to EKS.
+It also needs a base64 encoded version of the kube config file downloaded from 
+EKS. 
+
+Download the kube config file by adding a profile for this user to 
+`.aws/credentials` and using this command:
+```bash
+aws eks update-kubeconfig --profile funcx_github_actions --name funcx-dev    
+```
+
+I found that my file had an env setting for `AWS_PROFILE` which tied the 
+kubeconfig to the profile in my local `.aws/credentials` file. This didn't 
+work from the action, so I deleted the `env` section from my kube config.
+
+Create the Profile by:
+```yaml
+ cat ~/.kube/funcx-dev-github-staging| base64
+```
+
+and paste the results in as the `KUBE_CONFIG_DATA_STAGING` Secret.

--- a/cloudformation/eks-github-action-access.yaml
+++ b/cloudformation/eks-github-action-access.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eks-github-action-role
+  namespace: default
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/scale
+  verbs:
+  - patch
+  - get
+  - list
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: github-action-binding
+  namespace: default
+subjects:
+- kind: Group
+  name: github-action-group
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: eks-github-action-role
+  apiGroup: rbac.authorization.k8s.io

--- a/cloudformation/githubactions-role-binding.yaml
+++ b/cloudformation/githubactions-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: maintain-deployments
+  namespace: default
+subjects:
+- kind: User
+  name: githubactions # "name" is case sensitive
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  # "roleRef" specifies the binding to a Role / ClusterRole
+  kind: Role
+  name: eks-github-action-role
+  apiGroup: rbac.authorization.k8s.io

--- a/cloudformation/mapUsers.yaml
+++ b/cloudformation/mapUsers.yaml
@@ -1,0 +1,7 @@
+!!!!!!!!! This is a snippet. Add this to the aws-auth configMap with
+!!!!!!!!! kubectl edit -n kube-system configmap/aws-auth
+  mapUsers: |
+    - userarn: arn:aws:iam::512084481048:user/githubactions
+      username: githubactions
+      groups:
+        - github-action-binding


### PR DESCRIPTION
# Problem
We want to have a captive IAM account with Kubernetes credentials that can be summoned from GitHub Actions to redeploy pods upon merges into main branch.

Solution to [ClubHouse Story 8785](https://app.clubhouse.io/globus/story/8785/add-cd-pipeline-webservice-for-dev-environment)

# Approach
Added a new IAM account and provisioned it as a kubernetes user with a Role binding to allow scaling deployments only.

Provided instructions in [README](https://github.com/funcx-faas/helm-chart/blob/github_actions_ci/cloudformation/README.md) as well as kubernetes yaml files for creating the Role and binding it to this new user.
