### PR TITLE
Option to load confidential config settings out of secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,29 @@ postgresql:
     nodePort: 30432
     type: NodePort
 ```
+
+## Sealed Secrets
+The chart can take advantage of Bitnami's sealed secrets controller to encrypt
+sensitive config data so it can safely be checked into the GitHub repo.
+
+Create a secrets.yaml file with these values (the values need to be base64 
+encoded (use `echo "secret value" | base64`)). Use the file [example_secrets.yaml](example_secrets.yaml) to see
+how the file should be formatted and the names of the secrets.
+
+With kubectl configured to talk to the target cluster, encode the secrets file
+with the command:
+```console
+cat local-dev-secrets.yaml | \
+        kubeseal --controller-namespace kube-system \
+        --controller-name sealed-secrets \
+        --format yaml > local-dev-sealed-secrets.yaml
+```
 There are a few values that can be set to adjust the deployed system
 configuration
 
 | Value                          | Desciption                                                          | Default           |
 | ------------------------------ | ------------------------------------------------------------------- | ----------------- |
+| `secrets`                      | Name of a secret deployed into the cluster. Must follow example_secrets.yaml | -        |
 | `webService.image`             | Docker image name for the web service                               | funcx/web-service |
 | `webService.tag`               | Docker image tag for the web service                                | 213_helm_chart |
 | `webService.pullPolicy`        | Kubernetes pull policy for the web service container                | IfNotPresent |

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -69,3 +69,19 @@ Create the Profile by:
 ```
 
 and paste the results in as the `KUBE_CONFIG_DATA_STAGING` Secret.
+
+## Install Sealed Secrets
+We use Bitnami's Sealed Secrets Controller to allow us to check all of the
+config into GitHub. 
+
+Install sealed secrets helm chart
+```bash
+ helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets       
+ helm install sealed-secrets --namespace kube-system sealed-secrets/sealed-secrets
+```
+
+You will need the `kubeseal` command on your computer. Follow instructions for
+[the various options](https://github.com/bitnami-labs/sealed-secrets#homebrew)
+
+
+

--- a/example_secrets.yaml
+++ b/example_secrets.yaml
@@ -1,0 +1,11 @@
+# These are the secrets that are needed if you want to override values
+# in a secure way
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: funcx_secrets
+data:
+  globusClient: <<client ID>>
+  globusKey: <<secret key>>
+  externalPostgresURI: <<postgresql://_____________>>

--- a/funcx/templates/web-service-deployment.yaml
+++ b/funcx/templates/web-service-deployment.yaml
@@ -28,6 +28,24 @@ spec:
           value: "/opt/funcx/app.conf"
         - name: LOGLEVEL
           value: '{{ .Values.webService.loglevel }}'
+    {{- if .Values.secrets }}
+        - name: GLOBUS_CLIENT
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: globusClient
+        - name: GLOBUS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: globusKey
+        - name: SQLALCHEMY_DATABASE_URI
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: externalPostgresURI
+    {{- end }}
+
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.webService.pullPolicy }}

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -1,5 +1,10 @@
 # Default values for funcx.
 # This is a YAML-formatted file.
+
+# If this is provided, it must follow the example shown in example_secrets.yaml
+# The chart will mount environment variables from here into the app.
+secrets:
+
 ingress:
   enabled: false
   host: uc.ssl-hep.org


### PR DESCRIPTION
# Problem 
There are confidential settings to the app and other services that appear in `values.yaml` in plain text which prevents this from being committed to the git repo.

Story details: https://app.clubhouse.io/globus/story/8812

# Approach
Added a new value to `values.yaml`, `secrets`. If this is set, environment vars from that secret are mounted into the app pod when it launches.

Provided an example secrets yaml file, as well as instructions on how to install Bitnami's SealedSecrets operator which ties all of this together.
