### PR TITLE
Don't pick up env var for SQLALCHEMY_DATABASE_URI If Postgres deployed with chart

### DIFF
--- a/funcx/templates/web-service-deployment.yaml
+++ b/funcx/templates/web-service-deployment.yaml
@@ -39,11 +39,13 @@ spec:
             secretKeyRef:
               name: {{ .Values.secrets }}
               key: globusKey
+      {{- if not .Values.services.postgres.enabled }}
         - name: SQLALCHEMY_DATABASE_URI
           valueFrom:
             secretKeyRef:
               name: {{ .Values.secrets }}
               key: externalPostgresURI
+      {{- end }}
     {{- end }}
 
         tty: true


### PR DESCRIPTION
# Problem
If you use secrets at all then the SQLALCHEMY_DATABASE_URI always is overridden even when Postgres is deployed by the helm chart and the URI is calculated.

# Approach
Skip mounting that secret if `services.postgres.enabled`