### PR TITLE
Adding tests for smoke testing

### DIFF
--- a/smoke_tests/README.rst
+++ b/smoke_tests/README.rst
@@ -1,0 +1,29 @@
+Smoke Tests
+===========
+
+These tests are designed to quickly run some sanity checks on a deployment.
+The goals of these tests are to:
+* Quickly identify faults
+* Ensure that **all** components deployed correctly with the right versions
+
+How-to
+------
+
+These test have to be updated for each deployment, with updates to the `conftest.py`.
+Here are the config options that **must** be updated per release:
+
+
+* forwarder_version
+* api_version
+* funcx_version
+
+Running tests
+-------------
+
+* Install requirements:
+
+     >> pip install -r requirements.txt
+
+* Run tests:
+
+     >> pytest .

--- a/smoke_tests/conftest.py
+++ b/smoke_tests/conftest.py
@@ -1,0 +1,92 @@
+import pytest
+
+from funcx import FuncXClient
+from funcx.sdk.executor import FuncXExecutor
+
+config = {
+    "funcx_service_address": 'https://api2.funcx.org/v2',  # By default tests are against production
+    "endpoint_uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "results_ws_uri": "wss://api2.funcx.org/ws/v2/",
+    "forwarder_version": "0.3.2",
+    "api_version": "0.3.2",  # Version of funcx-web-service
+    "funcx_version": "0.3.2",  # Version of funcx-web-service
+    # This fn is public and searchable
+    "public_hello_fn_uuid": "b0a5d1a0-2b22-4381-b899-ba73321e41e0",
+    "tutorial_endpoint": '4b116d3c-1703-4f8f-9f6f-39921e5864df'  # Public tutorial endpoint
+}
+
+
+@pytest.fixture(autouse=True, scope="session")
+def load_funcx_session(request, pytestconfig):
+    """Load funcX sdk client for the entire test suite,
+
+    The special path `local` indicates that configuration will not come
+    from a pytest managed configuration file; in that case, see
+    load_dfk_local_module for module-level configuration management.
+    """
+
+    # config = pytestconfig.getoption('config')[0]
+
+
+def pytest_addoption(parser):
+    """Add funcx-specific command-line options to pytest."""
+    parser.addoption(
+        "--endpoint",
+        action="store",
+        metavar="endpoint",
+        nargs=1,
+        default=[config["endpoint_uuid"]],
+        help="Specify an active endpoint UUID",
+    )
+
+    parser.addoption(
+        "--service-address",
+        action="store",
+        metavar="service-address",
+        nargs=1,
+        default=[config["funcx_service_address"]],
+        help="Specify a funcX service address",
+    )
+
+    parser.addoption(
+        "--ws-uri",
+        action="store",
+        metavar="ws-uri",
+        nargs=1,
+        default=[config["results_ws_uri"]],
+        help="WebSocket URI to get task results",
+    )
+
+
+@pytest.fixture
+def fxc_args(pytestconfig):
+    fxc_args = {
+        "funcx_service_address": pytestconfig.getoption("--service-address")[0],
+        "results_ws_uri": pytestconfig.getoption("--ws-uri")[0],
+    }
+    fxc_args.update(config)
+    return fxc_args
+
+
+@pytest.fixture
+def fxc(fxc_args):
+    fxc = FuncXClient(**fxc_args)
+    return fxc
+
+
+@pytest.fixture
+def async_fxc(fxc_args):
+    fxc = FuncXClient(**fxc_args, asynchronous=True)
+    return fxc
+
+
+@pytest.fixture
+def fx(fxc):
+    fx = FuncXExecutor(fxc)
+    return fx
+
+
+@pytest.fixture
+def endpoint(pytestconfig):
+    endpoint = pytestconfig.getoption("--endpoint")[0]
+    return endpoint

--- a/smoke_tests/conftest.py
+++ b/smoke_tests/conftest.py
@@ -16,18 +16,6 @@ config = {
 }
 
 
-@pytest.fixture(autouse=True, scope="session")
-def load_funcx_session(request, pytestconfig):
-    """Load funcX sdk client for the entire test suite,
-
-    The special path `local` indicates that configuration will not come
-    from a pytest managed configuration file; in that case, see
-    load_dfk_local_module for module-level configuration management.
-    """
-
-    # config = pytestconfig.getoption('config')[0]
-
-
 def pytest_addoption(parser):
     """Add funcx-specific command-line options to pytest."""
     parser.addoption(
@@ -58,7 +46,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fxc_args(pytestconfig):
     fxc_args = {
         "funcx_service_address": pytestconfig.getoption("--service-address")[0],
@@ -68,25 +56,25 @@ def fxc_args(pytestconfig):
     return fxc_args
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fxc(fxc_args):
     fxc = FuncXClient(**fxc_args)
     return fxc
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def async_fxc(fxc_args):
     fxc = FuncXClient(**fxc_args, asynchronous=True)
     return fxc
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fx(fxc):
     fx = FuncXExecutor(fxc)
     return fx
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def endpoint(pytestconfig):
     endpoint = pytestconfig.getoption("--endpoint")[0]
     return endpoint

--- a/smoke_tests/test_async.py
+++ b/smoke_tests/test_async.py
@@ -1,0 +1,20 @@
+import random
+import asyncio
+
+
+def squared(x):
+    return x ** 2
+
+
+async def simple_task(fxc, endpoint):
+    squared_function = fxc.register_function(squared)
+    x = random.randint(0, 100)
+    task = fxc.run(x, endpoint_id=endpoint, function_id=squared_function)
+    result = await asyncio.wait_for(task, 20)
+    assert result == squared(x), "Got wrong answer"
+
+
+def test_simple(async_fxc, fxc_args):
+    """ Testing basic async functionality
+    """
+    async_fxc.loop.run_until_complete(simple_task(async_fxc, fxc_args['tutorial_endpoint']))

--- a/smoke_tests/test_executor.py
+++ b/smoke_tests/test_executor.py
@@ -1,0 +1,16 @@
+import random
+
+
+def double(x):
+    return x * 2
+
+
+def test_executor_basic(fx, fxc_args):
+    """ Test executor interface
+    """
+
+    endpoint = fxc_args['tutorial_endpoint']
+    x = random.randint(0, 100)
+    fut = fx.submit(double, x, endpoint_id=endpoint)
+
+    assert fut.result(timeout=10) == x * 2, "Got wrong answer"

--- a/smoke_tests/test_running_functions.py
+++ b/smoke_tests/test_running_functions.py
@@ -1,0 +1,41 @@
+import time
+
+
+def test_run_pre_registered_function(fxc, fxc_args):
+    """ This test confirms that we are connected to the default production DB
+    """
+
+    fn_id = fxc.run(endpoint_id=fxc_args['tutorial_endpoint'],
+                    function_id=fxc_args['public_hello_fn_uuid'])
+
+    time.sleep(10)
+
+    result = fxc.get_result(fn_id)
+    assert result == "Hello World!", f"Expected result: Hello World!, got {result}"
+
+
+def double(x):
+    return x * 2
+
+
+def test_batch(fxc, fxc_args):
+    """ Test batch submission and get_batch_result
+    """
+
+    double_fn = fxc.register_function(double)
+
+    inputs = list(range(10))
+    batch = fxc.create_batch()
+    tutorial_endpoint = fxc_args['tutorial_endpoint']
+
+    for x in inputs:
+        batch.add(x, endpoint_id=tutorial_endpoint, function_id=double_fn)
+
+    batch_res = fxc.batch_run(batch)
+
+    time.sleep(10)
+
+    results = fxc.get_batch_result(batch_res)
+
+    total = sum([results[tid]['result'] for tid in results])
+    assert total == 2 * (sum(inputs)), "Batch run results do not add up"

--- a/smoke_tests/test_version.py
+++ b/smoke_tests/test_version.py
@@ -1,0 +1,50 @@
+import requests
+
+
+def test_web_service(fxc, endpoint, fxc_args):
+    """ This test checks 1) web-service is online, 2) version of the funcx-web-service
+    """
+    service_address = fxc.funcx_service_address
+
+    response = requests.get(f"{service_address}/version")
+
+    assert response.status_code == 200, f"Request to version expected status_code=200, got {response.status_code} instead"
+
+    service_version = response.json()
+    api_version = fxc_args['api_version']
+    assert service_version == api_version, f"Expected API version:{api_version}, got {service_version}"
+
+
+def test_forwarder(fxc, endpoint, fxc_args):
+    """ This test checks 1) forwarder is online, 2) version of the forwarder
+    """
+    service_address = fxc.funcx_service_address
+
+    response = requests.get(f"{service_address}/version", params={'service': 'all'})
+
+    assert response.status_code == 200, f"Request to version expected status_code=200, got {response.status_code} instead"
+
+    forwarder_version = response.json()["forwarder"]
+    expected_version = fxc_args['forwarder_version']
+    assert forwarder_version == expected_version, \
+        f"Expected Forwarder version:{expected_version}, got {forwarder_version}"
+
+
+def say_hello():
+    return "Hello World!"
+
+
+def test_simple_function(fxc):
+    """ Test whether we can register a function
+    """
+    func_uuid = fxc.register_function(say_hello)
+    assert func_uuid is not None, "Invalid function uuid returned"
+
+
+def test_tutorial_ep_status(fxc, fxc_args):
+    """ Test whether the tutorial EP is online and reporting status
+    """
+    response = fxc.get_endpoint_status(fxc_args["tutorial_endpoint"])
+
+    assert response['status'] == "online", \
+        f"Expected tutorial EP to be online, got:{response['status']}"


### PR DESCRIPTION
Catch system failures on the hosted services side and the SDK that can cripple a release with a set of quick tests.

Note: The SDK goes through CI tests but does not run against the latest system release candidate, so it makes sense to test both.

*funcX = hosted services

* Call funcx /version route and confirm the version
       This will hit the funcx-web-service and return the version
* Call funcx /version with {service: all}
       * This will return version numbers of the service and forwarder and the min_ep_version and max_ep_version
       * We should confirm that these numbers match what we expect to be deployed
* Call the websocket service 
        * [TODO] Ask josh about how this is done now --- SKIP THIS
        * Josh says this is not public
* Call the web-service  /endpoint/status on the tutorial endpoint to confirm that the endpoint is online.
* To test whether the endpoint can run tests, you need the SDK.
* Run a pre-registered function to confirm that the system DB has remained online, and functions are not lost
* Run a new function

[ch10324]