### PR TITLE
Forwarder should support specific ports in helm values

### DIFF
--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -42,12 +42,8 @@ spec:
             fieldRef:
               fieldPath: status.podIP
     {{- end }}
-        - name: TASKS_PORT
-          value: "{{ .Values.forwarder.tasksPort }}"
-        - name: RESULTS_PORT
-          value: "{{ .Values.forwarder.resultsPort }}"
-        - name: COMMANDS_PORT
-          value: "{{ .Values.forwarder.commandsPort }}"
+        - name: ENDPOINT_BASE_PORT
+          value: "{{ .Values.forwarder.endpointBasePort }}"
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.forwarder.pullPolicy }}
@@ -57,14 +53,12 @@ spec:
         {{- end }}
         ports:
           - containerPort: 8080  # Forwarder REST port
-          - containerPort: {{ add .Values.forwarder.tasksPort 1 }}
-            hostPort: {{ add .Values.forwarder.tasksPort 1 }}
-          - containerPort: {{ add .Values.forwarder.resultsPort 1 }}
-            hostPort: {{ add .Values.forwarder.resultsPort 1 }}
-          - containerPort: {{ add .Values.forwarder.commandsPort 1 }}
-            hostPort: {{ add .Values.forwarder.commandsPort 1 }}
-          - containerPort: 55005 # Debug
-            hostPort: 55005
+          - containerPort: {{ add .Values.forwarder.endpointBasePort 1 }}
+            hostPort: {{ add .Values.forwarder.endpointBasePort 1 }}
+          - containerPort: {{ add .Values.forwarder.endpointBasePort 2 }}
+            hostPort: {{ add .Values.forwarder.endpointBasePort 2 }}
+          - containerPort: {{ add .Values.forwarder.endpointBasePort 3 }}
+            hostPort: {{ add .Values.forwarder.endpointBasePort 3 }}
         {{- if .Values.forwarder.server_cert }}
         volumeMounts:
         - name: funcx-forwarder-secret

--- a/funcx/templates/forwarder-service.yaml
+++ b/funcx/templates/forwarder-service.yaml
@@ -10,16 +10,16 @@ spec:
      targetPort: 8080
      name: "rest"
      protocol: TCP
-   - port: {{ .Values.forwarder.tasksPort }}
-     targetPort: {{ .Values.forwarder.tasksPort }}
+   - port: {{ .Values.forwarder.endpointBasePort }}
+     targetPort: {{ .Values.forwarder.endpointBasePort }}
      name: "zmq1"
      protocol: TCP
-   - port: {{ add .Values.forwarder.resultsPort 1 }}
-     targetPort: {{ add .Values.forwarder.resultsPort 1 }}
+   - port: {{ add .Values.forwarder.endpointBasePort 1 }}
+     targetPort: {{ add .Values.forwarder.endpointBasePort 1 }}
      name: "zmq2"
      protocol: TCP
-   - port: {{ add .Values.forwarder.commandsPort 2 }}
-     targetPort: {{ add .Values.forwarder.commandsPort 2 }}
+   - port: {{ add .Values.forwarder.endpointBasePort 2 }}
+     targetPort: {{ add .Values.forwarder.endpointBasePort 2 }}
      name: "zmq3"
      protocol: TCP
 
@@ -27,4 +27,4 @@ spec:
     app: {{ .Release.Name }}-forwarder
   type: ClusterIP
 
-  {{- end }}
+{{- end }}

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -36,9 +36,7 @@ forwarder:
   image: funcx/forwarder
   tag: main
   pullPolicy: Always
-  tasksPort: 55001
-  resultsPort: 55002
-  commandsPort: 55003
+  endpointBasePort: 55001
 
 # External services - these should be included for development environment
 # but on EKS we usually use the Amazon supported services


### PR DESCRIPTION
This is the helm chart updates to compliment [funcx-forwarder](https://github.com/funcx-faas/funcx-forwarder/pull/30) changes that support allowing custom forwarder port numbers.  Story details: https://app.shortcut.com/funcx/story/9611