### PR TITLE
Adding a deploy guide skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,12 +328,16 @@ rest can safely be skipped:
 * Deploy with:
     >> helm upgrade -f prod-values.yaml funcx funcx
 
----
-**NOTE**
-    It is preferable to upgrade rather than blow away the current deployment and redeploy because,
-    wiping the current deployment loses state that ties the Route53 entries to point at the ALB, and
-    any configuration on the ALB itself could be lost.
----
+> :warning: It is preferable to upgrade rather than blow away the current deployment and redeploy
+    because, wiping the current deployment loses state that ties the Route53 entries to point at
+    the ALB, and any configuration on the ALB itself could be lost.
+
+> :warning: If the deployment was wiped here are the steps:
+    * Go to Route53 on AWS Console and select the hosted zone: `dev.funcx.org`. Select the
+      appropriate A record for the deployment you are updating and edit the record to update the
+      value to something like `dualstack.k8s-default-funcxfun-dd14845f35-608065658.us-east-1.elb.amazonaws.com.`
+    * Add the ALB to the existing WAF Rules here: `https://console.aws.amazon.com/wafv2/homev2/web-acl/funcx-prod-web-acl/d82023f9-2cd8-4aed-b8e3-460dd399f4b0/overview?region=us-east-1#`
+
 
 * While a new forwarder will be launched on upgrade, the new one will not go online
   since it requires the ports that are in use by the older one. So you must manually
@@ -344,5 +348,5 @@ rest can safely be skipped:
 
   >> kubctl delete pods <NAME_OF_THE_OLDER_FUNCX_FORWARDER>
 
-  
+
 

--- a/README.md
+++ b/README.md
@@ -280,3 +280,56 @@ same Postgres URL found in the web app's config file (`/opt/funcx/app.conf`)
 ```console
 pgcli postgresql://funcx:XXXXXXXXXXXX@funcx-production-db.XXXXXX.rds.amazonaws.com:5432/funcx
 ```
+
+
+## Deployment/Release Guide
+
+
+The following is an incomplete guide to deploying a new release onto our development or production clusters.
+
+Here are the components that need updating as part of a release, in the order they should be updated
+due to dependencies:
+
+* funcx-common (Once @sirosen's changes are merged, the component below will need this component to be updated first)
+    * Update version number
+    * [Optional?] Release changes to Pypi
+
+* funcx-forwarder
+    * Update requirements to use latest funcx-common
+    * Update version number
+    * merge above changes to main in a PR
+    * Create a branch off of main with the version number, for, eg: 'v0.3.3'.
+      For dev releases, do alpha releases `v0.3.3a0`
+    * Ensure that the branch has the CI tests passing and the publish step working
+
+* funcx-web-service
+    * Same steps as funcx-forwarder
+
+* funcx-websocket-service
+    * Same steps as funcx-websocket-service
+
+* Update helm-charts
+    * Update the smoke-tests in the helm-charts to use the new version numbers in `conftest.py`
+
+* Prepare to deploy to cluster.
+    * Confirm that all the bits to be deployed should be available on dockerhub.
+    * Run `kubectl config current-context` which should return something like:
+
+    >> arn:aws:eks:us-east-1:512084481048:cluster/funcx-dev
+
+    * Make sure the right cluster is pointed to by kubectl, and use this terminal for all following steps.
+
+* Download the current values deployed to the target cluster as a backup.
+    >> kubectl get values
+
+* Update the values to use the release branchnames as the new tags
+
+* Deploy with:
+    >> helm upgrade -f prod-values.yaml funcx funcx
+
+Note: It is preferable to upgrade rather than blow away the current deployment and redeploy because,
+    wiping the current deployment loses state that ties the Route53 entries to point at the ALB, and
+    any configuration on the ALB itself could be lost (eg, throttling logic @joshbryan p.s check this?)
+
+
+

--- a/README.md
+++ b/README.md
@@ -328,9 +328,21 @@ rest can safely be skipped:
 * Deploy with:
     >> helm upgrade -f prod-values.yaml funcx funcx
 
-Note: It is preferable to upgrade rather than blow away the current deployment and redeploy because,
+---
+**NOTE**
+    It is preferable to upgrade rather than blow away the current deployment and redeploy because,
     wiping the current deployment loses state that ties the Route53 entries to point at the ALB, and
-    any configuration on the ALB itself could be lost (eg, throttling logic @joshbryan p.s check this?)
+    any configuration on the ALB itself could be lost.
+---
 
+* While a new forwarder will be launched on upgrade, the new one will not go online
+  since it requires the ports that are in use by the older one. So you must manually
+  delete the older funcx-forwarder pod.
 
+  >> kubectl get pods
+  # Find the older funcx-forwarder pod
+
+  >> kubctl delete pods <NAME_OF_THE_OLDER_FUNCX_FORWARDER>
+
+  
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ pgcli postgresql://funcx:XXXXXXXXXXXX@funcx-production-db.XXXXXX.rds.amazonaws.c
 The following is an incomplete guide to deploying a new release onto our development or production clusters.
 
 Here are the components that need updating as part of a release, in the order they should be updated
-due to dependencies:
+due to dependencies. Note that only components that have changes for release need to updated and the
+rest can safely be skipped:
 
 * funcx-common (Once @sirosen's changes are merged, the component below will need this component to be updated first)
     * Update version number


### PR DESCRIPTION
This is an early draft for a deployment guide. I wanted to put my notes out here so that we can compare notes.

I'm missing notes on deploying the test-endpoint on River, since we are moving that over to EKS.