### PR TITLE
Setup linting workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+exclude = .git,__pycache__,venv,.venv*
+max-line-length = 88
+ignore = W503,W504
+
+# 'black'-compatible config

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,23 @@
+name: build
+on:
+  push:
+  pull_request:
+
+# TODO: look into adding a `test` job which runs a "local" helm deploy in GH Actions
+# and tests the result with smoke tests
+jobs:
+  lint:
+    name: "Run Linting"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Setup Helm
+        uses: azure/setup-helm@v1
+      - name: Install pre-commit
+        run: python -m pip install -U pre-commit
+      - name: Run Linting
+        run: pre-commit run --all-files

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[isort]
+profile=black
+src_paths=smoke_tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+- repo: https://github.com/python/black
+  rev: 21.9b0
+  hooks:
+    - id: black
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+    - id: flake8
+      additional_dependencies: ['flake8-bugbear==21.4.3']
+- repo: https://github.com/timothycrosley/isort
+  rev: 5.9.1
+  hooks:
+    - id: isort
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.19.4
+  hooks:
+    - id: pyupgrade
+      args: ["--py36-plus"]
+- repo: https://github.com/gruntwork-io/pre-commit
+  rev: v0.1.15
+  hooks:
+    - id: helmlint

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,7 @@ shutdown-local-cluster:
 	@echo "\n= shutdown local cluster\n"
 	helm uninstall funcx
 	@echo "\n= local cluster shutdown complete\n"
+
+.PHONY: lint
+lint:
+	pre-commit run -a

--- a/smoke_tests/conftest.py
+++ b/smoke_tests/conftest.py
@@ -1,10 +1,10 @@
 import pytest
-
 from funcx import FuncXClient
 from funcx.sdk.executor import FuncXExecutor
 
 config = {
-    "funcx_service_address": 'https://api2.funcx.org/v2',  # By default tests are against production
+    # By default tests are against production
+    "funcx_service_address": "https://api2.funcx.org/v2",
     "endpoint_uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
     "results_ws_uri": "wss://api2.funcx.org/ws/v2/",
     "forwarder_version": "0.3.2",
@@ -12,7 +12,8 @@ config = {
     "funcx_version": "0.3.2",  # Version of funcx-web-service
     # This fn is public and searchable
     "public_hello_fn_uuid": "b0a5d1a0-2b22-4381-b899-ba73321e41e0",
-    "tutorial_endpoint": '4b116d3c-1703-4f8f-9f6f-39921e5864df'  # Public tutorial endpoint
+    # Public tutorial endpoint
+    "tutorial_endpoint": "4b116d3c-1703-4f8f-9f6f-39921e5864df",
 }
 
 

--- a/smoke_tests/test_async.py
+++ b/smoke_tests/test_async.py
@@ -1,5 +1,5 @@
-import random
 import asyncio
+import random
 
 
 def squared(x):
@@ -15,6 +15,7 @@ async def simple_task(fxc, endpoint):
 
 
 def test_simple(async_fxc, fxc_args):
-    """ Testing basic async functionality
-    """
-    async_fxc.loop.run_until_complete(simple_task(async_fxc, fxc_args['tutorial_endpoint']))
+    """Testing basic async functionality"""
+    async_fxc.loop.run_until_complete(
+        simple_task(async_fxc, fxc_args["tutorial_endpoint"])
+    )

--- a/smoke_tests/test_executor.py
+++ b/smoke_tests/test_executor.py
@@ -6,10 +6,9 @@ def double(x):
 
 
 def test_executor_basic(fx, fxc_args):
-    """ Test executor interface
-    """
+    """Test executor interface"""
 
-    endpoint = fxc_args['tutorial_endpoint']
+    endpoint = fxc_args["tutorial_endpoint"]
     x = random.randint(0, 100)
     fut = fx.submit(double, x, endpoint_id=endpoint)
 

--- a/smoke_tests/test_running_functions.py
+++ b/smoke_tests/test_running_functions.py
@@ -2,11 +2,12 @@ import time
 
 
 def test_run_pre_registered_function(fxc, fxc_args):
-    """ This test confirms that we are connected to the default production DB
-    """
+    """This test confirms that we are connected to the default production DB"""
 
-    fn_id = fxc.run(endpoint_id=fxc_args['tutorial_endpoint'],
-                    function_id=fxc_args['public_hello_fn_uuid'])
+    fn_id = fxc.run(
+        endpoint_id=fxc_args["tutorial_endpoint"],
+        function_id=fxc_args["public_hello_fn_uuid"],
+    )
 
     time.sleep(10)
 
@@ -19,14 +20,13 @@ def double(x):
 
 
 def test_batch(fxc, fxc_args):
-    """ Test batch submission and get_batch_result
-    """
+    """Test batch submission and get_batch_result"""
 
     double_fn = fxc.register_function(double)
 
     inputs = list(range(10))
     batch = fxc.create_batch()
-    tutorial_endpoint = fxc_args['tutorial_endpoint']
+    tutorial_endpoint = fxc_args["tutorial_endpoint"]
 
     for x in inputs:
         batch.add(x, endpoint_id=tutorial_endpoint, function_id=double_fn)
@@ -37,5 +37,5 @@ def test_batch(fxc, fxc_args):
 
     results = fxc.get_batch_result(batch_res)
 
-    total = sum([results[tid]['result'] for tid in results])
+    total = sum(results[tid]["result"] for tid in results)
     assert total == 2 * (sum(inputs)), "Batch run results do not add up"

--- a/smoke_tests/test_version.py
+++ b/smoke_tests/test_version.py
@@ -2,32 +2,39 @@ import requests
 
 
 def test_web_service(fxc, endpoint, fxc_args):
-    """ This test checks 1) web-service is online, 2) version of the funcx-web-service
-    """
+    """This test checks 1) web-service is online, 2) version of the funcx-web-service"""
     service_address = fxc.funcx_service_address
 
     response = requests.get(f"{service_address}/version")
 
-    assert response.status_code == 200, f"Request to version expected status_code=200, got {response.status_code} instead"
+    assert response.status_code == 200, (
+        "Request to version expected status_code=200, "
+        f"got {response.status_code} instead"
+    )
 
     service_version = response.json()
-    api_version = fxc_args['api_version']
-    assert service_version == api_version, f"Expected API version:{api_version}, got {service_version}"
+    api_version = fxc_args["api_version"]
+    assert (
+        service_version == api_version
+    ), f"Expected API version:{api_version}, got {service_version}"
 
 
 def test_forwarder(fxc, endpoint, fxc_args):
-    """ This test checks 1) forwarder is online, 2) version of the forwarder
-    """
+    """This test checks 1) forwarder is online, 2) version of the forwarder"""
     service_address = fxc.funcx_service_address
 
-    response = requests.get(f"{service_address}/version", params={'service': 'all'})
+    response = requests.get(f"{service_address}/version", params={"service": "all"})
 
-    assert response.status_code == 200, f"Request to version expected status_code=200, got {response.status_code} instead"
+    assert response.status_code == 200, (
+        "Request to version expected status_code=200, "
+        f"got {response.status_code} instead"
+    )
 
     forwarder_version = response.json()["forwarder"]
-    expected_version = fxc_args['forwarder_version']
-    assert forwarder_version == expected_version, \
-        f"Expected Forwarder version:{expected_version}, got {forwarder_version}"
+    expected_version = fxc_args["forwarder_version"]
+    assert (
+        forwarder_version == expected_version
+    ), f"Expected Forwarder version:{expected_version}, got {forwarder_version}"
 
 
 def say_hello():
@@ -35,16 +42,15 @@ def say_hello():
 
 
 def test_simple_function(fxc):
-    """ Test whether we can register a function
-    """
+    """Test whether we can register a function"""
     func_uuid = fxc.register_function(say_hello)
     assert func_uuid is not None, "Invalid function uuid returned"
 
 
 def test_tutorial_ep_status(fxc, fxc_args):
-    """ Test whether the tutorial EP is online and reporting status
-    """
+    """Test whether the tutorial EP is online and reporting status"""
     response = fxc.get_endpoint_status(fxc_args["tutorial_endpoint"])
 
-    assert response['status'] == "online", \
-        f"Expected tutorial EP to be online, got:{response['status']}"
+    assert (
+        response["status"] == "online"
+    ), f"Expected tutorial EP to be online, got:{response['status']}"


### PR DESCRIPTION
[Sample run is visible here.](https://github.com/funcx-faas/helm-chart/runs/3759362750).

I was going to work on the testsuite, but it's just so inconvenient to not be able to autoformat with `black`.
I'm fixing this now, rather than dealing with it and then adding it in later.
Upcoming testsuite improvements will be based off of this.

---

For the tests:
- black
- isort
- flake8

For helm:
- 'helm lint'

Runnable via pre-commit or via `make lint`.

GitHub Actions CI with a lint workflow runs all of these things.