### PR TITLE
Add a local mode to the smoke tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+exclude = .git,__pycache__,venv,.venv*
+max-line-length = 88
+ignore = W503,W504
+
+# 'black'-compatible config

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,23 @@
+name: build
+on:
+  push:
+  pull_request:
+
+# TODO: look into adding a `test` job which runs a "local" helm deploy in GH Actions
+# and tests the result with smoke tests
+jobs:
+  lint:
+    name: "Run Linting"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Setup Helm
+        uses: azure/setup-helm@v1
+      - name: Install pre-commit
+        run: python -m pip install -U pre-commit
+      - name: Run Linting
+        run: pre-commit run --all-files

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 deployed_values/
 *.log
+*.pyc
+__pycache__/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[isort]
+profile=black
+src_paths=smoke_tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+- repo: https://github.com/python/black
+  rev: 21.9b0
+  hooks:
+    - id: black
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+    - id: flake8
+      additional_dependencies: ['flake8-bugbear==21.4.3']
+- repo: https://github.com/timothycrosley/isort
+  rev: 5.9.1
+  hooks:
+    - id: isort
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.19.4
+  hooks:
+    - id: pyupgrade
+      args: ["--py36-plus"]
+- repo: https://github.com/gruntwork-io/pre-commit
+  rev: v0.1.15
+  hooks:
+    - id: helmlint

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ lint:
 	pre-commit run -a
 .PHONY: test-local
 test-local:
-	pytest smoke_tests/ --funcx-local
+	pytest smoke_tests/ --funcx-config local

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,7 @@ shutdown-local-cluster:
 	@echo "\n= shutdown local cluster\n"
 	helm uninstall funcx
 	@echo "\n= local cluster shutdown complete\n"
+
+.PHONY: lint
+lint:
+	pre-commit run -a

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,6 @@ shutdown-local-cluster:
 .PHONY: lint
 lint:
 	pre-commit run -a
+.PHONY: test-local
+test-local:
+	pytest smoke_tests/ --funcx-local

--- a/local_dev/README.md
+++ b/local_dev/README.md
@@ -2,6 +2,31 @@
 
 Tools for handling local development workflow.
 
+## Linting
+
+This repo has pre-commit hooks configured with [pre-commit](pre-commit.com).
+They are optional, but recommended.
+
+Install with
+
+    pipx install pre-commit
+
+or your preferred method for installing python tools.
+
+Setup the pre-commit hooks with
+
+    pre-commit install
+
+from the repo root.
+
+You can run hooks manually with
+
+    make lint
+
+And you can skip hooks when committing (if ever needed) with
+
+    git commit --no-verify
+
 ## Local Dev Deployments
 
 There are two main actions supported by the Makefile in the repo root:
@@ -104,3 +129,9 @@ webService:
   image: funcx_web_service
   tag: develop
 ```
+
+## Running Local Tests
+
+On a running deployment, with port forwarding enabled, you can run tests with
+`pytest`. For information on installing an running the tests, see
+[the Smoke Tests README](../smoke_tests).

--- a/smoke_tests/README.rst
+++ b/smoke_tests/README.rst
@@ -12,7 +12,6 @@ How-to
 These test have to be updated for each deployment, with updates to the `conftest.py`.
 Here are the config options that **must** be updated per release:
 
-
 * forwarder_version
 * api_version
 * funcx_version
@@ -27,3 +26,34 @@ Running tests
 * Run tests:
 
      >> pytest .
+
+Running Against Local K8s
+-------------------------
+
+To run against your local cluster, the default configuration will usually work.
+Use
+
+.. code-block:: bash
+
+    pytest . --funcx-local
+
+Or, from the repo root, invoke this with
+
+.. code-block:: bash
+
+    make test-local
+
+By default, this will look for a local endpoint ID in several locations. If no
+options are set, it uses the ID found in `~/.funcx/default/endpoint.json`.
+
+You can configure it to use a different local endpoint name (not `default`) by
+setting the `FUNCX_LOCAL_ENDPOINT_NAME` env var.
+
+Additional ways of settings the endpoint ID to use are:
+
+- set `FUNCX_LOCAL_ENDPOINT_ID` (higher precedence than `~/.funcx/` dir)
+
+- pass the `--endpoint <UUID>` option to `pytest` (highest precedence)
+
+All tests should pass when run locally. Tests which cannot work on a local
+stack are marked with `pytest.skip` and will be skipped.

--- a/smoke_tests/conftest.py
+++ b/smoke_tests/conftest.py
@@ -1,71 +1,127 @@
+import json
+import os
+
 import pytest
 from funcx import FuncXClient
 from funcx.sdk.executor import FuncXExecutor
 
-config = {
-    # By default tests are against production
-    "funcx_service_address": "https://api2.funcx.org/v2",
-    "endpoint_uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-    "results_ws_uri": "wss://api2.funcx.org/ws/v2/",
-    "forwarder_version": "0.3.2",
-    "api_version": "0.3.2",  # Version of funcx-web-service
-    "funcx_version": "0.3.2",  # Version of funcx-web-service
-    # This fn is public and searchable
-    "public_hello_fn_uuid": "b0a5d1a0-2b22-4381-b899-ba73321e41e0",
-    # Public tutorial endpoint
-    "tutorial_endpoint": "4b116d3c-1703-4f8f-9f6f-39921e5864df",
-}
+# the non-tutorial endpoint will be required, with the following priority order for
+# finding the ID:
+#
+#  1. `--endpoint` opt
+#  2. FUNX_LOCAL_ENDPOINT_ID (seen here)
+#  3. FUNX_LOCAL_ENDPOINT_NAME (the name of a dir in `~/.funcx/`)
+#  4. An endpoint ID found in ~/.funcx/default/endpoint.json
+#
+#  this var starts with the ID env var load
+_LOCAL_ENDPOINT_ID = os.getenv("FUNCX_LOCAL_ENDPOINT_ID")
+
+_CONFIGS = [
+    {
+        "config_name": "PROD",
+        # By default tests are against production, which means we do not need to pass
+        # any arguments to the client object (default will point at prod stack)
+        "client_args": {},
+        # assert versions are as expected on prod
+        "forwarder_version": "0.3.2",
+        "api_version": "0.3.2",
+        "funcx_version": "0.3.2",
+        # This fn is public and searchable
+        "public_hello_fn_uuid": "b0a5d1a0-2b22-4381-b899-ba73321e41e0",
+        # Public tutorial endpoint
+        "tutorial_endpoint": "4b116d3c-1703-4f8f-9f6f-39921e5864df",
+        # other endpoint to test
+        "endpoint_uuid": _LOCAL_ENDPOINT_ID,
+    },
+    {
+        "config_name": "LOCAL",
+        # localhost; typical defaults for a helm deploy
+        "client_args": {
+            "funcx_service_address": "http://localhost:5000/v2",
+            "results_ws_uri": "ws://localhost:6000/ws/v2/",
+        },
+        "endpoint_uuid": _LOCAL_ENDPOINT_ID,
+    },
+]
+
+
+def _get_config(name):
+    return next(x for x in _CONFIGS if x["config_name"] == name)
+
+
+def _get_local_endpoint_id():
+    # get the ID of a local endpoint, by name
+    # this is only called if
+    #  - there is no endpoint in the config (e.g. config via env var)
+    #  - `--endpoint` is not passed
+    local_endpoint_name = os.getenv("FUNCX_LOCAL_ENDPOINT_NAME", "default")
+    data_path = os.path.join(
+        os.path.expanduser("~"), ".funcx", local_endpoint_name, "endpoint.json"
+    )
+    with open(data_path) as fp:
+        data = json.load(fp)
+    return data["endpoint_id"]
 
 
 def pytest_addoption(parser):
     """Add funcx-specific command-line options to pytest."""
     parser.addoption(
-        "--endpoint",
-        action="store",
-        metavar="endpoint",
-        nargs=1,
-        default=[config["endpoint_uuid"]],
-        help="Specify an active endpoint UUID",
+        "--funcx-local",
+        action="store_true",
+        default=False,
+        help="Use local testing config",
     )
-
+    parser.addoption(
+        "--endpoint", metavar="endpoint", help="Specify an active endpoint UUID"
+    )
     parser.addoption(
         "--service-address",
-        action="store",
         metavar="service-address",
-        nargs=1,
-        default=[config["funcx_service_address"]],
         help="Specify a funcX service address",
     )
-
     parser.addoption(
-        "--ws-uri",
-        action="store",
-        metavar="ws-uri",
-        nargs=1,
-        default=[config["results_ws_uri"]],
-        help="WebSocket URI to get task results",
+        "--ws-uri", metavar="ws-uri", help="WebSocket URI to get task results"
     )
 
 
 @pytest.fixture(scope="session")
-def fxc_args(pytestconfig):
-    fxc_args = {
-        "funcx_service_address": pytestconfig.getoption("--service-address")[0],
-        "results_ws_uri": pytestconfig.getoption("--ws-uri")[0],
-    }
-    fxc_args.update(config)
-    return fxc_args
+def funcx_test_config(pytestconfig):
+    # start with basic config load
+    config = _get_config("PROD")
+    if pytestconfig.getoption("--funcx-local"):
+        config = _get_config("LOCAL")
+
+    # if `--endpoint` was passed or `endpoint_uuid` is present in config,
+    # handle those cases
+    endpoint = pytestconfig.getoption("--endpoint")
+    if endpoint:
+        config["endpoint_uuid"] = endpoint
+    elif config["endpoint_uuid"] is None:
+        config["endpoint_uuid"] = _get_local_endpoint_id()
+
+    # set URIs if passed
+    client_args = config["client_args"]
+    ws_uri = pytestconfig.getoption("--ws-uri")
+    api_uri = pytestconfig.getoption("--service-address")
+    if ws_uri:
+        client_args["results_ws_uri"] = ws_uri
+    if api_uri:
+        client_args["funcx_service_address"] = api_uri
+
+    return config
 
 
 @pytest.fixture(scope="session")
-def fxc(fxc_args):
-    fxc = FuncXClient(**fxc_args)
+def fxc(funcx_test_config):
+    client_args = funcx_test_config["client_args"]
+    fxc = FuncXClient(**client_args)
     return fxc
 
 
 @pytest.fixture(scope="session")
-def async_fxc(fxc_args):
-    fxc = FuncXClient(**fxc_args, asynchronous=True)
+def async_fxc(funcx_test_config):
+    client_args = funcx_test_config["client_args"]
+    fxc = FuncXClient(**client_args, asynchronous=True)
     return fxc
 
 
@@ -75,7 +131,35 @@ def fx(fxc):
     return fx
 
 
-@pytest.fixture(scope="session")
-def endpoint(pytestconfig):
-    endpoint = pytestconfig.getoption("--endpoint")[0]
+@pytest.fixture
+def endpoint(funcx_test_config):
+    return funcx_test_config["endpoint_uuid"]
+
+
+@pytest.fixture
+def _tutorial_endpoint(funcx_test_config):
+    return funcx_test_config.get("tutorial_endpoint")
+
+
+@pytest.fixture
+def tutorial_endpoint(_tutorial_endpoint):
+    if not _tutorial_endpoint:
+        pytest.skip("test requires the tutorial_endpoint")
+    return _tutorial_endpoint
+
+
+@pytest.fixture
+def tutorial_funcion_id(funcx_test_config):
+    funcid = funcx_test_config.get("public_hello_fn_uuid")
+    if not funcid:
+        pytest.skip("test requires the tutorial function")
+    return funcid
+
+
+@pytest.fixture
+def try_tutorial_endpoint(_tutorial_endpoint, endpoint):
+    # a variant of the tutorial_endpoint fixture which failsover to the
+    # non-tutorial endpoint if the tests are running locally, rather than skipping
+    if _tutorial_endpoint:
+        return _tutorial_endpoint
     return endpoint

--- a/smoke_tests/conftest.py
+++ b/smoke_tests/conftest.py
@@ -1,10 +1,10 @@
 import pytest
-
 from funcx import FuncXClient
 from funcx.sdk.executor import FuncXExecutor
 
 config = {
-    "funcx_service_address": 'https://api2.funcx.org/v2',  # By default tests are against production
+    # By default tests are against production
+    "funcx_service_address": "https://api2.funcx.org/v2",
     "endpoint_uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
     "results_ws_uri": "wss://api2.funcx.org/ws/v2/",
     "forwarder_version": "0.3.2",
@@ -12,7 +12,8 @@ config = {
     "funcx_version": "0.3.2",  # Version of funcx-web-service
     # This fn is public and searchable
     "public_hello_fn_uuid": "b0a5d1a0-2b22-4381-b899-ba73321e41e0",
-    "tutorial_endpoint": '4b116d3c-1703-4f8f-9f6f-39921e5864df'  # Public tutorial endpoint
+    # Public tutorial endpoint
+    "tutorial_endpoint": "4b116d3c-1703-4f8f-9f6f-39921e5864df",
 }
 
 

--- a/smoke_tests/test_async.py
+++ b/smoke_tests/test_async.py
@@ -14,8 +14,6 @@ async def simple_task(fxc, endpoint):
     assert result == squared(x), "Got wrong answer"
 
 
-def test_simple(async_fxc, fxc_args):
+def test_simple(async_fxc, try_tutorial_endpoint):
     """Testing basic async functionality"""
-    async_fxc.loop.run_until_complete(
-        simple_task(async_fxc, fxc_args["tutorial_endpoint"])
-    )
+    async_fxc.loop.run_until_complete(simple_task(async_fxc, try_tutorial_endpoint))

--- a/smoke_tests/test_async.py
+++ b/smoke_tests/test_async.py
@@ -1,5 +1,5 @@
-import random
 import asyncio
+import random
 
 
 def squared(x):
@@ -15,6 +15,7 @@ async def simple_task(fxc, endpoint):
 
 
 def test_simple(async_fxc, fxc_args):
-    """ Testing basic async functionality
-    """
-    async_fxc.loop.run_until_complete(simple_task(async_fxc, fxc_args['tutorial_endpoint']))
+    """Testing basic async functionality"""
+    async_fxc.loop.run_until_complete(
+        simple_task(async_fxc, fxc_args["tutorial_endpoint"])
+    )

--- a/smoke_tests/test_executor.py
+++ b/smoke_tests/test_executor.py
@@ -5,11 +5,10 @@ def double(x):
     return x * 2
 
 
-def test_executor_basic(fx, fxc_args):
+def test_executor_basic(fx, try_tutorial_endpoint):
     """Test executor interface"""
 
-    endpoint = fxc_args["tutorial_endpoint"]
     x = random.randint(0, 100)
-    fut = fx.submit(double, x, endpoint_id=endpoint)
+    fut = fx.submit(double, x, endpoint_id=try_tutorial_endpoint)
 
     assert fut.result(timeout=10) == x * 2, "Got wrong answer"

--- a/smoke_tests/test_executor.py
+++ b/smoke_tests/test_executor.py
@@ -6,10 +6,9 @@ def double(x):
 
 
 def test_executor_basic(fx, fxc_args):
-    """ Test executor interface
-    """
+    """Test executor interface"""
 
-    endpoint = fxc_args['tutorial_endpoint']
+    endpoint = fxc_args["tutorial_endpoint"]
     x = random.randint(0, 100)
     fut = fx.submit(double, x, endpoint_id=endpoint)
 

--- a/smoke_tests/test_running_functions.py
+++ b/smoke_tests/test_running_functions.py
@@ -1,13 +1,9 @@
 import time
 
 
-def test_run_pre_registered_function(fxc, fxc_args):
+def test_run_pre_registered_function(fxc, tutorial_endpoint, tutorial_funcion_id):
     """This test confirms that we are connected to the default production DB"""
-
-    fn_id = fxc.run(
-        endpoint_id=fxc_args["tutorial_endpoint"],
-        function_id=fxc_args["public_hello_fn_uuid"],
-    )
+    fn_id = fxc.run(endpoint_id=tutorial_endpoint, function_id=tutorial_funcion_id)
 
     time.sleep(10)
 
@@ -19,17 +15,16 @@ def double(x):
     return x * 2
 
 
-def test_batch(fxc, fxc_args):
+def test_batch(fxc, try_tutorial_endpoint):
     """Test batch submission and get_batch_result"""
 
     double_fn = fxc.register_function(double)
 
     inputs = list(range(10))
     batch = fxc.create_batch()
-    tutorial_endpoint = fxc_args["tutorial_endpoint"]
 
     for x in inputs:
-        batch.add(x, endpoint_id=tutorial_endpoint, function_id=double_fn)
+        batch.add(x, endpoint_id=try_tutorial_endpoint, function_id=double_fn)
 
     batch_res = fxc.batch_run(batch)
 

--- a/smoke_tests/test_running_functions.py
+++ b/smoke_tests/test_running_functions.py
@@ -2,11 +2,12 @@ import time
 
 
 def test_run_pre_registered_function(fxc, fxc_args):
-    """ This test confirms that we are connected to the default production DB
-    """
+    """This test confirms that we are connected to the default production DB"""
 
-    fn_id = fxc.run(endpoint_id=fxc_args['tutorial_endpoint'],
-                    function_id=fxc_args['public_hello_fn_uuid'])
+    fn_id = fxc.run(
+        endpoint_id=fxc_args["tutorial_endpoint"],
+        function_id=fxc_args["public_hello_fn_uuid"],
+    )
 
     time.sleep(10)
 
@@ -19,14 +20,13 @@ def double(x):
 
 
 def test_batch(fxc, fxc_args):
-    """ Test batch submission and get_batch_result
-    """
+    """Test batch submission and get_batch_result"""
 
     double_fn = fxc.register_function(double)
 
     inputs = list(range(10))
     batch = fxc.create_batch()
-    tutorial_endpoint = fxc_args['tutorial_endpoint']
+    tutorial_endpoint = fxc_args["tutorial_endpoint"]
 
     for x in inputs:
         batch.add(x, endpoint_id=tutorial_endpoint, function_id=double_fn)
@@ -37,5 +37,5 @@ def test_batch(fxc, fxc_args):
 
     results = fxc.get_batch_result(batch_res)
 
-    total = sum([results[tid]['result'] for tid in results])
+    total = sum(results[tid]["result"] for tid in results)
     assert total == 2 * (sum(inputs)), "Batch run results do not add up"

--- a/smoke_tests/test_version.py
+++ b/smoke_tests/test_version.py
@@ -2,32 +2,39 @@ import requests
 
 
 def test_web_service(fxc, endpoint, fxc_args):
-    """ This test checks 1) web-service is online, 2) version of the funcx-web-service
-    """
+    """This test checks 1) web-service is online, 2) version of the funcx-web-service"""
     service_address = fxc.funcx_service_address
 
     response = requests.get(f"{service_address}/version")
 
-    assert response.status_code == 200, f"Request to version expected status_code=200, got {response.status_code} instead"
+    assert response.status_code == 200, (
+        "Request to version expected status_code=200, "
+        f"got {response.status_code} instead"
+    )
 
     service_version = response.json()
-    api_version = fxc_args['api_version']
-    assert service_version == api_version, f"Expected API version:{api_version}, got {service_version}"
+    api_version = fxc_args["api_version"]
+    assert (
+        service_version == api_version
+    ), f"Expected API version:{api_version}, got {service_version}"
 
 
 def test_forwarder(fxc, endpoint, fxc_args):
-    """ This test checks 1) forwarder is online, 2) version of the forwarder
-    """
+    """This test checks 1) forwarder is online, 2) version of the forwarder"""
     service_address = fxc.funcx_service_address
 
-    response = requests.get(f"{service_address}/version", params={'service': 'all'})
+    response = requests.get(f"{service_address}/version", params={"service": "all"})
 
-    assert response.status_code == 200, f"Request to version expected status_code=200, got {response.status_code} instead"
+    assert response.status_code == 200, (
+        "Request to version expected status_code=200, "
+        f"got {response.status_code} instead"
+    )
 
     forwarder_version = response.json()["forwarder"]
-    expected_version = fxc_args['forwarder_version']
-    assert forwarder_version == expected_version, \
-        f"Expected Forwarder version:{expected_version}, got {forwarder_version}"
+    expected_version = fxc_args["forwarder_version"]
+    assert (
+        forwarder_version == expected_version
+    ), f"Expected Forwarder version:{expected_version}, got {forwarder_version}"
 
 
 def say_hello():
@@ -35,16 +42,15 @@ def say_hello():
 
 
 def test_simple_function(fxc):
-    """ Test whether we can register a function
-    """
+    """Test whether we can register a function"""
     func_uuid = fxc.register_function(say_hello)
     assert func_uuid is not None, "Invalid function uuid returned"
 
 
 def test_tutorial_ep_status(fxc, fxc_args):
-    """ Test whether the tutorial EP is online and reporting status
-    """
+    """Test whether the tutorial EP is online and reporting status"""
     response = fxc.get_endpoint_status(fxc_args["tutorial_endpoint"])
 
-    assert response['status'] == "online", \
-        f"Expected tutorial EP to be online, got:{response['status']}"
+    assert (
+        response["status"] == "online"
+    ), f"Expected tutorial EP to be online, got:{response['status']}"

--- a/smoke_tests/test_version.py
+++ b/smoke_tests/test_version.py
@@ -1,7 +1,7 @@
 import requests
 
 
-def test_web_service(fxc, endpoint, fxc_args):
+def test_web_service(fxc, endpoint, funcx_test_config):
     """This test checks 1) web-service is online, 2) version of the funcx-web-service"""
     service_address = fxc.funcx_service_address
 
@@ -13,13 +13,14 @@ def test_web_service(fxc, endpoint, fxc_args):
     )
 
     service_version = response.json()
-    api_version = fxc_args["api_version"]
-    assert (
-        service_version == api_version
-    ), f"Expected API version:{api_version}, got {service_version}"
+    api_version = funcx_test_config.get("api_version")
+    if api_version is not None:
+        assert (
+            service_version == api_version
+        ), f"Expected API version:{api_version}, got {service_version}"
 
 
-def test_forwarder(fxc, endpoint, fxc_args):
+def test_forwarder(fxc, endpoint, funcx_test_config):
     """This test checks 1) forwarder is online, 2) version of the forwarder"""
     service_address = fxc.funcx_service_address
 
@@ -31,10 +32,11 @@ def test_forwarder(fxc, endpoint, fxc_args):
     )
 
     forwarder_version = response.json()["forwarder"]
-    expected_version = fxc_args["forwarder_version"]
-    assert (
-        forwarder_version == expected_version
-    ), f"Expected Forwarder version:{expected_version}, got {forwarder_version}"
+    expected_version = funcx_test_config.get("forwarder_version")
+    if expected_version:
+        assert (
+            forwarder_version == expected_version
+        ), f"Expected Forwarder version:{expected_version}, got {forwarder_version}"
 
 
 def say_hello():
@@ -47,9 +49,9 @@ def test_simple_function(fxc):
     assert func_uuid is not None, "Invalid function uuid returned"
 
 
-def test_tutorial_ep_status(fxc, fxc_args):
+def test_ep_status(fxc, try_tutorial_endpoint):
     """Test whether the tutorial EP is online and reporting status"""
-    response = fxc.get_endpoint_status(fxc_args["tutorial_endpoint"])
+    response = fxc.get_endpoint_status(try_tutorial_endpoint)
 
     assert (
         response["status"] == "online"


### PR DESCRIPTION
There are now two configs, PROD and LOCAL, and appropriate tooling to dispatch over them. `make test-local` now runs local tests.

Additional behaviors / testsuite changes:
- in local mode, don't check version values (too likely to fail spuriously during dev)
- the `try_tutorial_endpoint` fixture uses the tutorial_endpoint ID, but falls back to the local `endpoint_id`
- separate general test config data from client init args
- various ways of setting local endpoint ID are supported, with a default that looks in `~/.funcx/default/endpoint.json`
- any test which strictly requires the tutorial EP or tutorial function will auto-skip when the tests run locally