### PR TITLE
Port ingress template to newer API

### DIFF
--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -7,7 +7,8 @@ cluster:
 .PHONY: install-alb-controler
 install-alb-controler:
 	helm repo add eks https://aws.github.io/eks-charts
-	helm upgrade -i aws-load-balancer-controller --version 1.1.6 eks/aws-load-balancer-controller -n kube-system --set clusterName=funcx-$(ENVIRONMENT) --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=us-east-1 --set vpcId=vpc-0d3b9f7c3a9c6c1ba
+	helm repo update eks
+	helm upgrade -i aws-load-balancer-controller --version 1.2.7 eks/aws-load-balancer-controller -n kube-system --set clusterName=funcx-$(ENVIRONMENT) --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=us-east-1 --set vpcId=vpc-0d3b9f7c3a9c6c1ba
 
 .PHONY: install-fluentbit
 install-fluentbit:

--- a/funcx/templates/ingress.yaml
+++ b/funcx/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -23,12 +23,18 @@ spec:
   - host: {{ .Values.ingress.host }}
     http:
       paths:
-      - path: /v2/*
+      - path: /v2
+        pathType: Prefix
         backend:
-          serviceName: {{ .Release.Name }}-funcx-web-service
-          servicePort: 8000
-      - path: /ws/v2/*
+          service:
+            name: {{ .Release.Name }}-funcx-web-service
+            port:
+              number: 8000
+      - path: /ws/v2
+        pathType: Prefix
         backend:
-          serviceName: {{ .Release.Name }}-funcx-websocket-service
-          servicePort: 6000
+          service:
+            name: {{ .Release.Name }}-funcx-websocket-service
+            port:
+              number: 6000
 {{- end }}


### PR DESCRIPTION
The API previously used stopped being supported in kubernetes v1.22.
The new API is supported in kubernetes v1.19.

kubernetes as installed recently by minikube for development is
giving 1.22

the hosted clusters are at kubernetes 1.18 at the moment, so would need
upgrading before this PR could be used against them.

I have tested that I can access the web service on my own k8s install
using the nginx ingress, by running:

```
minikube addons enable ingress
```

then setting this in my deployed_values/values.yaml file:

```
ingress:
  enabled: true
  host: amber.cqx.ltd.uk
```

and checking:

```
$ curl http://amber.cqx.ltd.uk/v2/version
"0.3.3"
```

I have not tested the EKS configuration path. I have not tested the
websocket service vs nginx path.