### PR TITLE
Remove 'funcx_version' from test data

### DIFF
--- a/smoke_tests/README.rst
+++ b/smoke_tests/README.rst
@@ -14,7 +14,6 @@ Here are the config options that **must** be updated per release:
 
 * forwarder_version
 * api_version
-* funcx_version
 
 Running tests
 -------------

--- a/smoke_tests/conftest.py
+++ b/smoke_tests/conftest.py
@@ -24,7 +24,6 @@ _CONFIGS = {
         # assert versions are as expected on prod
         "forwarder_version": "0.3.3",
         "api_version": "0.3.3",
-        "funcx_version": "0.3.3",
         # This fn is public and searchable
         "public_hello_fn_uuid": "b0a5d1a0-2b22-4381-b899-ba73321e41e0",
         # Public tutorial endpoint


### PR DESCRIPTION
It is never used.

---

See also: https://github.com/funcx-faas/funcx-web-service/pull/263