### PR TITLE
[WIP] Add S3 storage settings and pass to forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ Here are some values that can be overriden:
 | `services.redis.enabled`         | Deploy redis along with service?                             | true |
 | `services.redis.externalHost`  | If redis is deployed externally, what is the host name?    |  |
 | `services.redis.externalPort`  | If redis is deployed externally, what is the port?    |  6379 |
+| `storage.awsSecrets`           | Name of Kubernetes secret that holds the AWS credentials |    |
+| `storage.s3Bucket`             | S3 bucket where storage will write results and payloads | funcx |
+| `storage.redisThreshold`       | Threshold to switch large results to S3 from redis (in bytes) | 20000 |
 
 
 ## Sealed Secrets
@@ -224,6 +227,22 @@ cat local-dev-secrets.yaml | \
         --controller-name sealed-secrets \
         --format yaml > local-dev-sealed-secrets.yaml
 ```
+
+## AWS Secrets for S3 Storage
+If you are using S3 storage, you will need to provide AWS credentials via a
+secret. These secrets can be installed into your cluster by creating a yaml file
+like
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  AWS_ACCESS_KEY_ID: <<base64 encoded access key>>
+  AWS_SECRET_ACCESS_KEY: <<base64 encoded secret>>
+```
+
 
 ## Subcharts
 This chart uses two subcharts to supply dependent services. You can update

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -48,6 +48,22 @@ spec:
           value: "{{ .Values.forwarder.resultsPort }}"
         - name: COMMANDS_PORT
           value: "{{ .Values.forwarder.commandsPort }}"
+
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.storage.awsSecrets }}
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.storage.awsSecrets }}
+              key: AWS_SECRET_ACCESS_KEY
+
+        - name: S3_BUCKET_NAME
+          value: "{{ .Values.storage.s3Bucket }}"
+        - name: REDIS_STORAGE_THRESHOLD
+          value: "{{ .Values.storage.redisThreshold }}"
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.forwarder.pullPolicy }}

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -9,6 +9,10 @@ ingress:
   enabled: false
   host: uc.ssl-hep.org
 
+storage:
+  s3Bucket: funcx
+  redisThreshold: 20000
+  awsSecrets:
 webService:
   image: funcx/web-service
   tag: main


### PR DESCRIPTION
# Problem
Now that we have a forwarder that can use S3 storage, we need to be able to configure it via environment variables. We need to protect the AWS credentials

# Approach
1. Added instructions on how to create a secret with the AWS ID and Secret Key
2. Added values for providing the name of this secret, as well as the S3 bucket name to use and the threshold of when we switch from Redis to S3
3. Pass these into forwarder pod via environment vars

