### PR TITLE
Externalize AWS Service Account

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Here are some values that can be overriden:
 | `storage.awsSecrets`           | Name of Kubernetes secret that holds the AWS credentials |    |
 | `storage.s3Bucket`             | S3 bucket where storage will write results and payloads | funcx |
 | `storage.redisThreshold`       | Threshold to switch large results to S3 from redis (in bytes) | 20000 |
+| `storage.s3ServiceAccount`     | Kubernetes Service Account to use for accessing AWS access tokens (blank to skip service account) | <blank> |
 
 
 ## Sealed Secrets

--- a/funcx/templates/container-service-deployment.yaml
+++ b/funcx/templates/container-service-deployment.yaml
@@ -18,6 +18,8 @@ spec:
         image: {{ .Values.containerService.image }}:{{ .Values.containerService.tag }}
         tty: true
         stdin: true
+        ports:
+          - containerPort: 5000
         imagePullPolicy: {{ .Values.containerService.pullPolicy }}
         {{- if .Values.containerService.resources }}
         resources:

--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -13,7 +13,9 @@ spec:
       labels:
         app: {{ .Release.Name }}-forwarder
     spec:
-      serviceAccountName: funcx-service
+      {{- if .Values.storage.s3ServiceAccount }}
+      serviceAccountName: {{- .Values.storage.s3ServiceAccount }}
+      {{- end }}
       hostNetwork: true
       containers:
       - name: {{ .Release.Name }}-forwarder

--- a/funcx/templates/web-service-deployment.yaml
+++ b/funcx/templates/web-service-deployment.yaml
@@ -12,9 +12,11 @@ spec:
       labels:
         app: {{ .Release.Name }}-funcx-web-service
     spec:
-      serviceAccountName: funcx-service
+      {{- if .Values.storage.s3ServiceAccount }}
+      serviceAccountName: {{- .Values.storage.s3ServiceAccount }}
       securityContext:
         fsGroup: 1000
+      {{- end }}
     {{- if .Values.services.postgres.enabled }}
       initContainers:
       - name: check-postgresql

--- a/funcx/templates/websocket-service-deployment.yaml
+++ b/funcx/templates/websocket-service-deployment.yaml
@@ -12,9 +12,11 @@ spec:
       labels:
         app: {{ .Release.Name }}-funcx-websocket-service
     spec:
-      serviceAccountName: funcx-service
+      {{- if .Values.storage.s3ServiceAccount }}
+      serviceAccountName: {{- .Values.storage.s3ServiceAccount }}
       securityContext:
         fsGroup: 1000
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-funcx-websocket-service
         image: {{ .Values.websocketService.image }}:{{ .Values.websocketService.tag }}

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -13,6 +13,8 @@ storage:
   s3Bucket: funcx
   redisThreshold: 20000
   awsSecrets:
+  s3ServiceAccount:
+
 webService:
   image: funcx/web-service
   tag: main


### PR DESCRIPTION
# Problem
We need to use a serviceAccount to access the node's AWS Credentials for working with S3. This doesn't work on local deployments

# Approach
Made the service account name a property in `values.yaml`.

Configured the deployments to skip the section on ServiceAccount when this is blank