### PR TITLE
Add RabbitMQ Queue TTL

### DIFF
--- a/funcx/templates/forwarder-deployment.yaml
+++ b/funcx/templates/forwarder-deployment.yaml
@@ -39,6 +39,8 @@ spec:
     {{- else }}
           value: "{{  .Values.services.rabbitmq.externalURI }}"
     {{- end }}
+        - name: RABBITMQ_QUEUE_TTL
+          value: "{{  .Values.services.rabbitmq.queueTTL }}"
     {{- if not .Values.forwarder.useAWSMetadataServer }}
         - name: ADVERTISED_FORWARDER_ADDRESS
           valueFrom:

--- a/funcx/templates/websocket-service-deployment.yaml
+++ b/funcx/templates/websocket-service-deployment.yaml
@@ -40,6 +40,8 @@ spec:
     {{- else }}
           value: "{{  .Values.services.rabbitmq.externalURI }}"
     {{- end }}
+        - name: RABBITMQ_QUEUE_TTL
+          value: "{{  .Values.services.rabbitmq.queueTTL }}"
         - name: WEB_SERVICE_URI
           value: "http://{{ .Release.Name }}-funcx-web-service:8000"
 

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -66,7 +66,8 @@ services:
   rabbitmq:
     enabled: true
     externalHost: rabbitmq
-    queueTTL: 60
+    # TTL in seconds
+    queueTTL: 604800
 
 postgresql:
   postgresqlUsername: funcx

--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -66,6 +66,7 @@ services:
   rabbitmq:
     enabled: true
     externalHost: rabbitmq
+    queueTTL: 60
 
 postgresql:
   postgresqlUsername: funcx


### PR DESCRIPTION
Pass `rabbitmq.queueTTL` value to both forwarder and websocket service as an env var