### PR TITLE
Set the default ep version to python 3.9

### DIFF
--- a/funcx/values.yaml
+++ b/funcx/values.yaml
@@ -33,7 +33,7 @@ endpoint:
   enabled: true
 
 funcx_endpoint:
-  tag: main
+  tag: main-3.9
   funcXServiceAddress: http://funcx-funcx-web-service:8000
   pullPolicy: Always
 


### PR DESCRIPTION
Sets the default endpoint tag to `main-3.9` in values.yaml. The old `main` tag is no longer updated after the publishing action was set to include python version.